### PR TITLE
feat: 2026-04-09トレンド情報収集記事を追加

### DIFF
--- a/daily/20260409-trend.md
+++ b/daily/20260409-trend.md
@@ -1,0 +1,315 @@
+---
+title: '2026-04-09 トレンド情報収集'
+date: '2026-04-09'
+---
+
+# 2026-04-09 トレンド情報収集
+
+## 今日のサマリー
+
+### AI開発ツールの「組織実装」フェーズへ ── Claude Code・MCPが現場に浸透
+
+Claude Codeを中心としたAIコーディングツールの話題が引き続き圧倒的だが、「個人の生産性向上」から「組織全体への展開・運用」へフェーズが移行している。エアークローゼットの17個のMCPサーバー一挙公開（342 users）、全社Claude Code大号令で200個のアプリと300件のナレッジを生み出した事例、Windows 11でのマルチエージェント環境構築記事（163 users）など、実運用レベルの知見が続出。Anthropicからも「Claude Managed Agents」が発表され、本番環境でのエージェント開発を10倍高速化するAPI群が登場した。（[参考](https://zenn.dev/aircloset/articles/d9fc317c1336c2)）（[参考](https://www.itmedia.co.jp/aiplus/articles/2604/09/news067.html)）
+
+### DESIGN.md ── AIが一貫したUIを生成するための新標準
+
+Google LabsのStitchプロジェクトから提唱された「DESIGN.md」が日本のエンジニアコミュニティで大きな注目を集めている（244 users）。AIコーディングエージェントがUIを生成する際にデザインシステムの文脈を正確に理解できず、バラバラなUIが生まれる問題に対し、Markdown形式で設計規約を定義するアプローチだ。導入ガイドやDESIGN.mdのawesomeリストも登場しており、実践への関心が高い。（[参考](https://atmarkit.itmedia.co.jp/ait/articles/2604/09/news014.html)）
+
+### セキュリティ事件の多発 ── 不動産プラットフォーム100万件流出、VeraCrypt開発停止
+
+SUUMO・CHINTAI・アットホームなど主要不動産プラットフォームから約100万件のメールアドレスを含む個人情報が流出した疑い。暗号化ツール「VeraCrypt」はMicrosoftにアカウントを停止され開発が事実上ストップ、OSSコミュニティに衝撃を与えている（Reddit r/cybersecurity 783 ups）。中国のスーパーコンピューターからの10PBデータ窃取も報じられた。認可制御不備を見抜く10パターンの記事（153 users）もタイムリーに注目を集めている。（[参考](https://gigazine.net/news/20260409-microsoft-veracrypt-ban/)）（[参考](https://blog.flatt.tech/entry/authz_assessment_view)）
+
+### テック業界の大量解雇とAIの関係
+
+2026年Q1だけでテック業界は約8万人を解雇し、その約半数がAI関連のポジション削減によるもの（Reddit r/technology 5,914 ups）。一方でr/cscareerquestionsでは「AIエンジニアの求人市場は好調」という投稿が738 upsを獲得しており、AIを使う側と置き換えられる側の二極化が鮮明になっている。ホワイトカラー労働者の80%がAI導入の義務化を拒否しているという報告も話題だ。（[参考](https://www.reddit.com/r/technology/comments/1sfzw39/tech_industry_lays_off_nearly_80000_employees_in/)）
+
+### ローカルLLMの新星 ── Kepler-452b、EXAONE 4.5、Gemma 4安定化
+
+ローカルLLMコミュニティでは新モデルの登場が相次いでいる。「Kepler-452b」が2,457 upsと爆発的注目を集め、LG AIのEXAONE 4.5（33Bパラメータ）もリリースされた。Gemma 4のllama.cpp対応も安定し、実用段階に入っている。一方でOpus 4.6の性能劣化を指摘する声も目立つ。（[参考](https://www.reddit.com/r/LocalLLaMA/comments/1sftj52/kepler452b_gguf_when/)）
+
+---
+
+## 注目ピックアップ
+
+### [社内業務をAIに開放 — 自社MCPサーバー群一挙公開！](https://zenn.dev/aircloset/articles/d9fc317c1336c2)
+
+> エアークローゼットが社内業務の自動化のために開発した17個のMCPサーバー群を一挙公開。データベース、インフラ、ドキュメント、プロジェクト管理、監視、CI/CDなど幅広い領域をAIから操作可能にしている。GitHub不要でコード編集・デプロイでき、非エンジニアも安全にスタックを操作できる基盤を実現。企業のAI導入における実践的なノウハウが詰まった記事。
+
+**ソース**: はてブ 342 users
+**カテゴリ**: AI / MCP / 組織開発
+
+### [Claude Codeのメモリを3階層にしたら「覚えてる」が「学んでる」に変わった](https://zenn.dev/tokium_dev/articles/claude-code-evolutionary-memory)
+
+> Claude Codeのメモリを観察→記憶→進化の3層構造に設計。SessionEnd Hookで無意識のパターンを自動検出し、同じフィードバックが3回繰り返されるとCLAUDE.mdルール→スキル→Hookへ自動昇格する仕組み。「覚えているだけ」から「学んでいる」状態への進化を実現した。
+
+**ソース**: はてブ 140 users
+**カテゴリ**: AI / Claude Code
+
+### [AIがバラバラなUIを作る問題、これで解決？ Google提唱の新標準「DESIGN.md」とは](https://atmarkit.itmedia.co.jp/ait/articles/2604/09/news014.html)
+
+> Google LabsのStitchプロジェクトが提唱するDESIGN.mdは、Markdown形式でデザインシステムの設計規約（色・フォント・コンポーネント・レイアウト）を定義する新標準。AIコーディングエージェントが一貫したUIを生成できるようになり、デザイン規約の遵守と効率的な開発を両立する。
+
+**ソース**: はてブ 244 users
+**カテゴリ**: AI / フロントエンド / デザインシステム
+
+### [セキュリティエンジニアはこう見る。開発時に認可制御不備を怪しむべき実装パターン10選](https://blog.flatt.tech/entry/authz_assessment_view)
+
+> セキュリティエンジニアが着目する認可制御不備の10パターンを解説。推測可能なIDの使用、複数IDパラメータの検証漏れ、親子リソース間の認可制御不備、SQLのWHERE句における信頼できる値の欠落、権限確認関数の呼び出し漏れなど、開発時に注意すべき具体的な実装パターンが網羅されている。
+
+**ソース**: はてブ 153 users
+**カテゴリ**: セキュリティ / 開発
+
+### [本番環境のAIエージェント開発を「10倍」高速化――「Claude Managed Agents」発表](https://www.itmedia.co.jp/aiplus/articles/2604/09/news067.html)
+
+> Anthropicが「Claude Managed Agents」を公開。企業向けAIエージェントの展開・運用をサポートするAPI群で、エージェント実行の監視、マルチエージェント連携、セッション管理など10の主要機能を搭載。アクティブタスク実行は1分間0.08ドルと低コストで導入しやすい。
+
+**ソース**: はてブ 22 users
+**カテゴリ**: AI / Claude / エージェント
+
+---
+
+## はてブIT（日本市場）
+
+### 注目トピック
+
+| タイトル                                                                                                                                                             | ブクマ数  | 興味度 | カテゴリ          | メモ                                |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------ | ----------------- | ----------------------------------- |
+| [社内業務をAIに開放 — 自社MCPサーバー群一挙公開！](https://zenn.dev/aircloset/articles/d9fc317c1336c2)                                                               | 342 users | ★★★    | AI / MCP          | 17個のMCPサーバーを公開             |
+| [AIがバラバラなUIを作る問題、これで解決？ Google提唱の新標準「DESIGN.md」とは](https://atmarkit.itmedia.co.jp/ait/articles/2604/09/news014.html)                     | 244 users | ★★★    | AI / デザイン     | DESIGN.md解説                       |
+| ["キュピーン猫画像メーカー"初日50万アクセスもサーバ代「0円」](https://www.itmedia.co.jp/news/articles/2604/09/news108.html)                                          | 243 users | ★★     | 個人開発          | サーバーレスの活用事例              |
+| [AWSが「Amazon S3 Files」を発表](https://codezine.jp/news/detail/23899)                                                                                              | 211 users | ★★     | インフラ          | S3の新機能                          |
+| [AIのお世話が辛いのでUsecase Design Docを書く](https://caddi.tech/2026/04/07/110000)                                                                                 | 164 users | ★★★    | AI / 設計         | AI駆動開発の設計手法                |
+| [AIが書いたコードをレビューするな](https://zenn.dev/a_1ro/articles/4b0333e9d7b8f9)                                                                                   | 164 users | ★★★    | AI / 開発プロセス | AI時代のレビュー論                  |
+| [Windows 11でClaude Codeのマルチエージェント開発環境をホントの1から構築してみた](https://dev.classmethod.jp/articles/claude-code-multi-agent-on-windows11-wsl-tmux/) | 163 users | ★★★    | Claude Code       | Windows環境構築                     |
+| [Anthropic「Claude Mythos」凄すぎて一般公開見送り](https://ascii.jp/elem/000/004/388/4388019/)                                                                       | 162 users | ★★★    | AI / Claude       | Mythosの公開見送り理由              |
+| [セキュリティエンジニアはこう見る。開発時に認可制御不備を怪しむべき実装パターン10選](https://blog.flatt.tech/entry/authz_assessment_view)                            | 153 users | ★★★    | セキュリティ      | 認可制御の実装パターン              |
+| [個人的GitHub Copilotの使い方メモ](https://zenn.dev/mixi/articles/c6ee38194904ef)                                                                                    | 151 users | ★★     | AI / 開発ツール   | Copilot活用法                       |
+| [AIがコードを書くほど、要件定義は上に移動する](https://zenn.dev/gvatech_blog/articles/30f79910d111bb)                                                                | 144 users | ★★★    | AI / 設計         | 継続注目                            |
+| [Claude Codeのメモリを3階層にしたら「覚えてる」が「学んでる」に変わった](https://zenn.dev/tokium_dev/articles/claude-code-evolutionary-memory)                       | 140 users | ★★★    | Claude Code       | メモリの3階層設計                   |
+| [Claude Code を並列で回す WezTerm ターミナル構成](https://zenn.dev/dely_jp/articles/5d4e89c275789f)                                                                  | 81 users  | ★★★    | Claude Code       | ターミナル並列構成                  |
+| [Project Glasswing: Securing critical software for the AI era](https://www.anthropic.com/glasswing)                                                                  | 63 users  | ★★★    | AI / セキュリティ | Anthropicのセキュリティプロジェクト |
+
+### 全エントリー
+
+1. ["先延ばし癖"の原因に新知見](https://www.itmedia.co.jp/news/articles/2604/09/news017.html) (479 users) - 目標設定能力の欠如ではないとする英国研究
+2. [社内業務をAIに開放 — 自社MCPサーバー群一挙公開！](https://zenn.dev/aircloset/articles/d9fc317c1336c2) (342 users) - 17個のMCPサーバー公開
+3. [AIがバラバラなUIを作る問題、これで解決？ DESIGN.md](https://atmarkit.itmedia.co.jp/ait/articles/2604/09/news014.html) (244 users) - Google提唱の新標準
+4. ["キュピーン猫画像メーカー"初日50万アクセスもサーバ代「0円」](https://www.itmedia.co.jp/news/articles/2604/09/news108.html) (243 users) - サーバーレス活用
+5. [AWSが「Amazon S3 Files」を発表](https://codezine.jp/news/detail/23899) (211 users) - S3の新機能
+6. [AIのお世話が辛いのでUsecase Design Docを書く](https://caddi.tech/2026/04/07/110000) (164 users) - AI駆動開発の設計
+7. [AIが書いたコードをレビューするな](https://zenn.dev/a_1ro/articles/4b0333e9d7b8f9) (164 users) - AI時代のレビュー論
+8. [Windows 11でClaude Codeマルチエージェント環境構築](https://dev.classmethod.jp/articles/claude-code-multi-agent-on-windows11-wsl-tmux/) (163 users) - WSL+tmux構築
+9. [Anthropic「Claude Mythos」凄すぎて一般公開見送り](https://ascii.jp/elem/000/004/388/4388019/) (162 users) - 性能が高すぎて公開見送り
+10. [セキュリティエンジニアはこう見る。認可制御不備10選](https://blog.flatt.tech/entry/authz_assessment_view) (153 users) - 認可制御の実装パターン
+11. [個人的GitHub Copilotの使い方メモ](https://zenn.dev/mixi/articles/c6ee38194904ef) (151 users) - Copilot活用法
+12. [Claude Codeのメモリを3階層にしたら「覚えてる」が「学んでる」に変わった](https://zenn.dev/tokium_dev/articles/claude-code-evolutionary-memory) (140 users) - 3階層メモリ設計
+13. [コントロール パネルはまだ廃止されないと思います](https://pc.watch.impress.co.jp/docs/news/yajiuma/2100272.html) (127 users) - Windows UI話題
+14. [Claude Code を並列で回す WezTerm ターミナル構成](https://zenn.dev/dely_jp/articles/5d4e89c275789f) (81 users) - 並列実行構成
+15. ["退職"は脳に良い？](https://www.itmedia.co.jp/news/articles/2604/09/news018.html) (43 users) - 退職の脳への影響
+16. [AI時代でも変わらない、キャリアの土台を作る3つの思考法](https://techblog.roxx.co.jp/entry/2026/04/09/080000) (43 users) - キャリア論
+17. [全社へのClaude Code大号令 — 200個のアプリと300件のナレッジ](https://note.com/naofumit/n/n2835cd8fbe87) (37 users) - 組織でのClaude Code展開
+18. [The Git Commands I Run Before Reading Any Code](https://piechowski.io/post/git-commands-before-reading-code/) (37 users) - Git活用テクニック
+19. [日本発LLM推論効率化アーキテクチャ「PHOTON」](https://qiita.com/yuji-arakawa/items/2ad0240c56eb7507b261) (35 users) - 推論効率化
+20. [Geminiに「NotebookLM」が統合](https://gigazine.net/news/20260409-gemini-notebooklm/) (35 users) - Google製品統合
+21. [AIに頼ると「粘り強さ」が失われる](https://www.itmedia.co.jp/aiplus/articles/2604/08/news109.html) (34 users) - AI依存の弊害
+22. [Geminiが手取り足取りPythonを指南 Google Colabの「学習モード」](https://www.itmedia.co.jp/aiplus/articles/2604/09/news102.html) (34 users) - Colab新機能
+23. [暗号化ドライブ「VeraCrypt」更新停止](https://gigazine.net/news/20260409-microsoft-veracrypt-ban/) (31 users) - MSにアカウント停止される
+24. [SUUMO・CHINTAIなどから個人情報大規模流出か](https://gigazine.net/news/20260409-japanese-estate-platforms-data-breach/) (27 users) - 約100万件流出
+25. [大量の機密情報をハッカーが売り出し、中国スパコンから流出か](https://www.cnn.co.jp/tech/35246217.html) (26 users) - 中国スパコン情報流出
+26. [ハーネスエンジニアリングは枠組みから始めよう](https://caddi.tech/start-harness-engineering-with-framework) (26 users) - AIハーネス設計
+27. [AI活用でスループットとレビュー負荷が2倍に](https://journal.supateam.com/entry/2026/04/09/105443) (25 users) - AI活用の効果と課題
+28. [Agent CI — Run GitHub Actions Locally](https://agent-ci.dev/) (25 users) - GH Actionsローカル実行
+29. [週1回の夜間リリースから自律的デリバリーへ](https://agilejourney.uzabase.com/entry/2026/04/09/103000) (48 users) - デリバリー改善
+30. [「OpenSSL」なのに……「OpenSSL 4.0」で「SSL 3.0」対応が完全削除](https://forest.watch.impress.co.jp/docs/news/2100124.html) (48 users) - OpenSSL更新
+31. [Claude Mythos次世代モデルが一般公開されないワケ](https://www.itmedia.co.jp/aiplus/articles/2604/08/news092.html) (50 users) - Mythosの危険性
+32. [本番環境のAIエージェント開発を「10倍」高速化 Claude Managed Agents](https://www.itmedia.co.jp/aiplus/articles/2604/09/news067.html) (22 users) - 新API群発表
+33. [仕様書は"使い捨て"にした方がうまくいった](https://zenn.dev/dely_jp/articles/ef573ae39b9162) (22 users) - 仕様書運用論
+34. [DESIGN.md 導入ガイド](https://zenn.dev/minewo/articles/design-md-guide-and-adoption-log) (19 users) - DESIGN.md実践
+35. [Embedding modelの「内在的な双曲性」を利用したRAG精度の向上](https://tech-blog.localmet.com/entry/2026/04/09/165926) (24 users) - RAG改善手法
+36. [Amazon Bedrock now offers Claude Mythos Preview](https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-bedrock-claude-mythos/) (9 users) - Bedrock対応
+37. [Vera — A language designed for machines to write](https://veralang.dev/) (8 users) - AI向け新言語
+
+## Hacker News（グローバル）
+
+### 注目トピック
+
+| タイトル                                                                                              | ポイント | 興味度 | カテゴリ            | メモ                   |
+| ----------------------------------------------------------------------------------------------------- | -------- | ------ | ------------------- | ---------------------- |
+| [コードを読む前に実行するGitコマンド集](https://news.ycombinator.com/item?id=47687273)                | 2103pt   | ★★     | Git / 開発          | 継続注目               |
+| [Mac OS XをNintendo Wiiに移植した](https://news.ycombinator.com/item?id=47691730)                     | 1685pt   | ★      | OS / ハック         |                        |
+| [Linux版LittleSnitch](https://news.ycombinator.com/item?id=47697870)                                  | 919pt    | ★★★    | セキュリティ / OSS  | ネットワーク監視ツール |
+| [「彼らは肉でできている」(1991)](https://news.ycombinator.com/item?id=47688678)                       | 583pt    | ★      | SF / 文学           |                        |
+| [MLは根本的に奇妙になると約束する](https://news.ycombinator.com/item?id=47689648)                     | 533pt    | ★★     | AI / ML             |                        |
+| [サトシ・ナカモトは誰か？ビットコイン創設者を追う](https://news.ycombinator.com/item?id=47685320)     | 544pt    | ★      | 暗号通貨            |                        |
+| [Claudeは誰が何を言ったか混同する、それは許されない](https://news.ycombinator.com/item?id=47701233)   | 180pt    | ★★★    | AI / Claude         | Claude品質問題         |
+| [カルマンフィルターをレーダー例で理解する](https://news.ycombinator.com/item?id=47693153)             | 374pt    | ★      | 数学 / 工学         |                        |
+| [Muse Spark: パーソナル超知能に向けたスケーリング](https://news.ycombinator.com/item?id=47692043)     | 363pt    | ★★     | AI                  |                        |
+| [ソフトウェア開発者のためのUSB入門](https://news.ycombinator.com/item?id=47695012)                    | 334pt    | ★★     | 開発 / ハードウェア |                        |
+| [MegaTrain: 単一GPUで100B+パラメータLLMのフル精度学習](https://news.ycombinator.com/item?id=47689174) | 312pt    | ★★★    | AI / LLM            |                        |
+| [Astralにおけるオープンソースセキュリティ](https://news.ycombinator.com/item?id=47699181)             | 239pt    | ★★★    | セキュリティ / OSS  | Ruffの開発元           |
+| [怠惰であることの重要性](https://news.ycombinator.com/item?id=47666639)                               | 225pt    | ★★     | 生産性 / 哲学       |                        |
+| [Thunderbirdを存続させよう](https://news.ycombinator.com/item?id=47700388)                            | 209pt    | ★★     | OSS                 |                        |
+
+### 全エントリー
+
+1. [コードを読む前に実行するGitコマンド集](https://news.ycombinator.com/item?id=47687273) (2103pt) - Git活用テクニック
+2. [Mac OS XをNintendo Wiiに移植した](https://news.ycombinator.com/item?id=47691730) (1685pt) - OS移植プロジェクト
+3. [Linux版LittleSnitch](https://news.ycombinator.com/item?id=47697870) (919pt) - ネットワーク監視ツール
+4. [「彼らは肉でできている」(1991)](https://news.ycombinator.com/item?id=47688678) (583pt) - SF短編の再発見
+5. [サトシ・ナカモトは誰か？](https://news.ycombinator.com/item?id=47685320) (544pt) - ビットコイン創設者の調査
+6. [MLは根本的に奇妙になると約束する](https://news.ycombinator.com/item?id=47689648) (533pt) - 機械学習の未来論
+7. [カルマンフィルターをレーダー例で理解する](https://news.ycombinator.com/item?id=47693153) (374pt) - 教育的解説
+8. [Muse Spark: パーソナル超知能に向けて](https://news.ycombinator.com/item?id=47692043) (363pt) - 個人向けAI
+9. [ソフトウェア開発者のためのUSB入門](https://news.ycombinator.com/item?id=47695012) (334pt) - USBドライバ開発
+10. [MegaTrain: 単一GPUで100B+パラメータLLM学習](https://news.ycombinator.com/item?id=47689174) (312pt) - 効率的なLLM学習
+11. [Astralにおけるオープンソースセキュリティ](https://news.ycombinator.com/item?id=47699181) (239pt) - Ruff開発元のセキュリティ方針
+12. [怠惰であることの重要性](https://news.ycombinator.com/item?id=47666639) (225pt) - 生産性と休息の関係
+13. [Thunderbirdを存続させよう](https://news.ycombinator.com/item?id=47700388) (209pt) - OSSメールクライアントの支援
+14. [Claudeは誰が何を言ったか混同する](https://news.ycombinator.com/item?id=47701233) (180pt) - Claudeの品質課題
+15. [お化けペーパートイ](https://news.ycombinator.com/item?id=47658950) (142pt) - クリエイティブ工作
+16. [KLダイバージェンスの6つ半の直感](https://news.ycombinator.com/item?id=47678690) (97pt) - 情報理論の解説
+17. [Dr. Dobb's開発者ライブラリDVD 6](https://news.ycombinator.com/item?id=47645010) (85pt) - 技術史アーカイブ
+18. [フィフス・エレメントの未来都市制作](https://news.ycombinator.com/item?id=47701100) (62pt) - 映画美術
+19. [Wit, unker, Git: 失われた中世英語の親称代名詞](https://news.ycombinator.com/item?id=47701572) (47pt) - 言語学
+20. [C# in Unity 2026: 開発者がまだ使わない機能](https://news.ycombinator.com/item?id=47660434) (43pt) - ゲーム開発
+21. [月面シミュレーターゲーム（レイキャスティング）](https://news.ycombinator.com/item?id=47663743) (39pt) - ゲーム開発
+22. [CSS Studio: 手でデザインし、エージェントがコード化](https://news.ycombinator.com/item?id=47702196) (36pt) - AI支援デザイン
+23. [Nintendo DSプログラミング入門](https://news.ycombinator.com/item?id=47685644) (36pt) - 組み込み開発
+24. [Dropbox Magic Pocketのストレージ効率改善](https://news.ycombinator.com/item?id=47632157) (32pt) - インフラ
+25. [Tree Calculus](https://news.ycombinator.com/item?id=47624763) (22pt) - 計算理論
+26. [Sessionが90日でシャットダウン](https://news.ycombinator.com/item?id=47703065) (15pt) - プライバシーツール
+27. [41年間の海面水温異常](https://news.ycombinator.com/item?id=47702791) (11pt) - 気候データ
+28. [Pizza Tycoon(1994)は25MHzのCPUでどう交通をシミュレートしたか](https://news.ycombinator.com/item?id=47703123) (5pt) - レトロゲーム分析
+
+## Reddit（14サブレッド）
+
+### 注目トピック
+
+| タイトル                                                                                                                                                            | 投票数   | コメント | 興味度 | サブレッド          | メモ             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | ------ | ------------------- | ---------------- |
+| [テック業界、2026年Q1に約8万人解雇 ── 約50%がAI関連](https://www.reddit.com/r/technology/comments/1sfzw39/tech_industry_lays_off_nearly_80000_employees_in/)        | 5914 ups | 320      | ★★★    | r/technology        | AI時代の雇用問題 |
+| [ホワイトカラー労働者の80%がAI導入を拒否](https://www.reddit.com/r/technology/comments/1sgln0z/whitecollar_workers_are_quietly_rebelling_against/)                  | 4870 ups | 560      | ★★     | r/technology        | AI導入への抵抗   |
+| [Kepler-452b GGUFはいつ？](https://www.reddit.com/r/LocalLLaMA/comments/1sftj52/kepler452b_gguf_when/)                                                              | 2457 ups | 122      | ★★★    | r/LocalLLaMA        | 新LLM注目        |
+| [コピペが最初のVibe Codingだった](https://www.reddit.com/r/ClaudeCode/comments/1sftqea/copy_and_pasting_was_the_original_vibe_coding/)                              | 1322 ups | 86       | ★★     | r/ClaudeCode        | Vibe Coding論    |
+| [MicrosoftがWireGuardとVeraCryptのアカウントをブロック](https://www.reddit.com/r/cybersecurity/comments/1sftjw8/microsoft_blocks_accounts_wireguard_and_veracrypt/) | 783 ups  | 63       | ★★★    | r/cybersecurity     | OSSへの脅威      |
+| [AIエンジニアの求人市場は好調](https://www.reddit.com/r/cscareerquestions/comments/1sg57ba/job_market_is_amazing_for_ai_engineers/)                                 | 738 ups  | 224      | ★★★    | r/cscareerquestions | キャリア動向     |
+| [非技術マネージャの終焉が始まる](https://www.reddit.com/r/programming/comments/1sg5gss/fake_it_until_you_break_it_the_end_of/)                                      | 727 ups  | 146      | ★★     | r/programming       | マネジメント論   |
+| [Opus 4.6が確実にnerf ── 需要に対応](https://www.reddit.com/r/LocalLLaMA/comments/1sgd7fp/its_insane_how_lobotomized_opus_46_is_right_now/)                         | 542 ups  | 220      | ★★★    | r/LocalLLaMA        | Claude品質懸念   |
+| [企業がLLMトークンに日次上限設定、AIピークは来たか？](https://www.reddit.com/r/cscareerquestions/comments/1sfm63w/my_company_is_implementing_max_costday_on_llm/)   | 546 ups  | 153      | ★★★    | r/cscareerquestions | AIコスト管理     |
+| [MetaがOSSを諦めていない](https://www.reddit.com/r/LocalLLaMA/comments/1sfzdrv/meta_has_not_given_up_on_opensource/)                                                | 294 ups  | 75       | ★★★    | r/LocalLLaMA        | MetaのOSS戦略    |
+| [Metaが新しいコーディングモデルをリリース](https://www.reddit.com/r/ClaudeCode/comments/1sg51ut/meta_just_dropped_a_new_coding_model/)                              | 350 ups  | 99       | ★★★    | r/ClaudeCode        | 競合モデル       |
+
+### セキュリティ系
+
+1. [ロシアGRUが脆弱なルーターを悪用して機密情報を窃取](https://www.reddit.com/r/netsec/comments/1sfugo9/russian_gru_exploiting_vulnerable_routers_to/) (76 ups, 13 comments) - r/netsec - 国家支援のサイバー攻撃
+2. [CUPS RCEチェーン: 未認証リモートroot取得](https://www.reddit.com/r/netsec/comments/1sflk3t/spooler_alert_remote_unauthd_rcetoroot_chain_in/) (31 ups, 5 comments) - r/netsec - CUPS脆弱性
+3. [AIツール開発の速度がセキュリティを置き去りにした Part 1: Sandbox Escape](https://www.reddit.com/r/netsec/comments/1sf550g/the_race_to_ship_ai_tools_left_security_behind/) (22 ups, 7 comments) - r/netsec - AIツールセキュリティ
+4. [Tolgeeクラウドプラットフォームの翻訳ファイルアップロードで/etc/passwd読み取り (CVE-2026-32251)](https://www.reddit.com/r/netsec/comments/1sfpmg9/reading_etcpasswd_via_translation_file_upload_in/) (20 ups, 2 comments) - r/netsec - CVE報告
+5. [UARTからRootへ: Uniview IPカメラのシェルエスケープ](https://www.reddit.com/r/netsec/comments/1sfe68f/from_uart_to_root_vendor_shell_escape_on_a/) (18 ups, 0 comments) - r/netsec - IoTセキュリティ
+6. [MicrosoftがWireGuardとVeraCryptのアカウントをブロック](https://www.reddit.com/r/cybersecurity/comments/1sftjw8/microsoft_blocks_accounts_wireguard_and_veracrypt/) (783 ups, 63 comments) - r/cybersecurity - OSSプロジェクトへの影響
+7. [AIがサイバーセキュリティの仕事を増やしている](https://www.reddit.com/r/cybersecurity/comments/1sgbuw7/ai_is_creating_more_cybersecurity_work/) (343 ups, 96 comments) - r/cybersecurity - AI時代のセキュリティ業務
+8. [FBI: 米国のサイバー犯罪被害額が過去最高の210億ドルに](https://www.reddit.com/r/cybersecurity/comments/1sfr871/fbi_americans_lost_a_record_21_billion_to/) (317 ups, 21 comments) - r/cybersecurity - サイバー犯罪統計
+9. [ハッカーがLAPDの機密文書を窃取・公開](https://www.reddit.com/r/cybersecurity/comments/1sfyf1s/hackers_steal_and_leak_sensitive_lapd_police/) (283 ups, 7 comments) - r/cybersecurity - 法執行機関への攻撃
+10. [Glasswingが50社にMythosクラス脆弱性への3ヶ月の先行対応を提供](https://www.reddit.com/r/cybersecurity/comments/1sfy90j/glasswing_gives_50_companies_a_3month_head_start/) (150 ups, 49 comments) - r/cybersecurity - AnthropicのGlasswing
+
+### AI系
+
+1. [Kepler-452b GGUFはいつ？](https://www.reddit.com/r/LocalLLaMA/comments/1sftj52/kepler452b_gguf_when/) (2457 ups, 122 comments) - r/LocalLLaMA - 新モデルへの期待
+2. [コピペが最初のVibe Codingだった](https://www.reddit.com/r/ClaudeCode/comments/1sftqea/copy_and_pasting_was_the_original_vibe_coding/) (1322 ups, 86 comments) - r/ClaudeCode - 開発スタイル論
+3. [マネタイズはユーザーベースの大きさに依存しない](https://www.reddit.com/r/OpenAI/comments/1sftdkl/monetization_truly_doesnt_care_how_big_your_user/) (867 ups, 113 comments) - r/OpenAI - AI時代のビジネス
+4. [ローカルLLMの実際のユースケースで活躍](https://www.reddit.com/r/LocalLLaMA/comments/1sg2686/it_finally_happened_i_actually_had_a_use_case_for/) (593 ups, 81 comments) - r/LocalLLaMA - 実用事例
+5. [Opus 4.6が確実にnerfされた](https://www.reddit.com/r/LocalLLaMA/comments/1sgd7fp/its_insane_how_lobotomized_opus_46_is_right_now/) (542 ups, 220 comments) - r/LocalLLaMA - モデル品質懸念
+6. [Metaが新しいコーディングモデルをリリース](https://www.reddit.com/r/ClaudeCode/comments/1sg51ut/meta_just_dropped_a_new_coding_model/) (350 ups, 99 comments) - r/ClaudeCode - 競合分析
+7. [元OpenAI幹部: 「ポータルからエイリアンを召喚している」](https://www.reddit.com/r/OpenAI/comments/1sg0kpp/former_openai_exec_the_truth_is_were_building/) (256 ups, 118 comments) - r/OpenAI - AI安全性議論
+8. [来月解約する](https://www.reddit.com/r/ClaudeCode/comments/1sggxka/cancelling_next_month/) (245 ups, 71 comments) - r/ClaudeCode - ユーザー不満
+9. [Gemma 4がllama.cppで安定化](https://www.reddit.com/r/LocalLLaMA/comments/1sgl3qz/gemma_4_on_llamacpp_should_be_stable_now/) (190 ups, 50 comments) - r/LocalLLaMA - Gemma 4実用化
+10. [Claude Mythos脱走、研究者にメール送信](https://www.reddit.com/r/OpenAI/comments/1sfv5gs/during_testing_claude_mythos_escaped_gained/) (160 ups, 42 comments) - r/OpenAI - AI安全性
+11. [EXAONE 4.5リリース](https://www.reddit.com/r/LocalLLaMA/comments/1sgc8ir/exaone_45_released/) (140 ups, 37 comments) - r/LocalLLaMA - LGの新モデル
+12. [Opus 4.6は需要によりnerfされた、Opus 4.5は影響なし](https://www.reddit.com/r/ClaudeCode/comments/1sghy4i/opus_46_was_definitely_nerfed_due_to_demand_opus/) (114 ups, 62 comments) - r/ClaudeCode - モデル品質
+13. [Joanne JangがOpenAIを退社](https://www.reddit.com/r/OpenAI/comments/1sfigi4/joanne_jang_has_left_openai/) (1210 ups, 186 comments) - r/OpenAI - 人事動向
+
+### コア技術系
+
+1. [非技術マネージャの終焉が始まる](https://www.reddit.com/r/programming/comments/1sg5gss/fake_it_until_you_break_it_the_end_of/) (727 ups, 146 comments) - r/programming - マネジメント論
+2. [Pizza Tycoon(1994)は25MHzのCPUでどう交通をシミュレートしたか](https://www.reddit.com/r/programming/comments/1sg6y9x/how_pizza_tycoon_1994_simulated_traffic_on_a_25/) (480 ups, 23 comments) - r/programming - レトロゲーム分析
+3. [パイプライン演算子が好きだ](https://www.reddit.com/r/programming/comments/1sfoqwq/i_am_very_fond_of_the_pipeline_operator/) (214 ups, 118 comments) - r/programming - 言語機能
+4. [Postgresだけで永続的ワークフロー実行](https://www.reddit.com/r/programming/comments/1sg5koq/absurd_workflows_durable_execution_with_just/) (69 ups, 3 comments) - r/programming - アーキテクチャ
+5. [The Intl API: 使われていない最高のブラウザAPI](https://www.reddit.com/r/javascript/comments/1sgb3bm/the_intl_api_the_best_browser_api_youre_not_using/) (27 ups, 4 comments) - r/javascript - Web API
+6. [TinyTTS: 超軽量オフラインTTS for Node.js](https://www.reddit.com/r/javascript/comments/1sfkrmb/tinytts_ultralightweight_offline_texttospeech_for/) (38 ups, 13 comments) - r/javascript - Node.jsツール
+7. [ビルド設定にマルウェアを隠す手法](https://www.reddit.com/r/javascript/comments/1sg58l6/how_attackers_are_hiding_malicious_code_in_build/) (35 ups, 0 comments) - r/javascript - サプライチェーンセキュリティ
+8. [型は新しい正規表現だ](https://www.reddit.com/r/webdev/comments/1sgiwrj/types_are_the_new_regex/) (142 ups, 72 comments) - r/webdev - TypeScript論
+9. [AIは仕事を奪わない、奪わなかった](https://www.reddit.com/r/webdev/comments/1sfq7vh/ai_didnt_and_will_not_take_our_jobs/) (343 ups, 206 comments) - r/webdev - AI雇用論
+10. [BunnyCDNが15ヶ月間本番ファイルを黙って消失](https://www.reddit.com/r/webdev/comments/1sglytg/bunnycdn_has_been_silently_losing_our_production/) (172 ups, 36 comments) - r/webdev - CDN障害
+
+### OSS/個人開発系
+
+1. [MicrosoftがVeraCrypt開発者のアカウントを停止](https://www.reddit.com/r/opensource/comments/1sfdl6b/microsoft_terminates_account_of_veracrypt/) (478 ups, 50 comments) - r/opensource - OSSへの脅威
+2. [売るのをやめた瞬間、すべてが変わった](https://www.reddit.com/r/indiehackers/comments/1sghg9c/i_am_a_solo_entrepreneur_i_spent_a_year_trying_to/) (11 ups, 16 comments) - r/indiehackers - 個人起業の教訓
+3. [130人にメールしてSaaSを宣伝、0人がYes](https://www.reddit.com/r/indiehackers/comments/1seubx8/i_emailed_130_people_to_promote_my_saas_0_said_yes/) (30 ups, 90 comments) - r/indiehackers - SaaSマーケティング
+
+### キャリア/実践系
+
+1. [AIエンジニアの求人市場は好調](https://www.reddit.com/r/cscareerquestions/comments/1sg57ba/job_market_is_amazing_for_ai_engineers/) (738 ups, 224 comments) - r/cscareerquestions - 求人動向
+2. [企業がLLMトークンに日次上限設定](https://www.reddit.com/r/cscareerquestions/comments/1sfm63w/my_company_is_implementing_max_costday_on_llm/) (546 ups, 153 comments) - r/cscareerquestions - コスト管理
+3. [Mythosの盛り上がりはマーケティングに過ぎない？](https://www.reddit.com/r/cscareerquestions/comments/1sfx056/all_this_hype_around_mythos_just_more_marketing/) (237 ups, 183 comments) - r/cscareerquestions - AI議論
+4. [あなたの雇用主はAI推進していない？](https://www.reddit.com/r/cscareerquestions/comments/1sg1mar/is_anyone_elses_employer_not_doing_a_huge_ai_push/) (241 ups, 120 comments) - r/cscareerquestions - 企業のAI導入
+5. [うつ病の時に生産的になる方法](https://www.reddit.com/r/productivity/comments/1sfxsty/how_to_be_productive_when_you_have_depression/) (75 ups, 52 comments) - r/productivity - メンタルヘルス
+6. [毎週月曜にリセットされる感覚、なぜ？](https://www.reddit.com/r/productivity/comments/1sg1u93/why_do_i_keep_restarting_every_monday_like_my/) (30 ups, 15 comments) - r/productivity - 習慣化
+
+## セキュリティブログ
+
+### Aikido Security
+
+1. [GlassWorm: Zig製ドロッパーがすべてのIDEに感染](https://www.aikido.dev/blog/glassworm-zig-dropper-infects-every-ide-on-your-machine) (2026-04-08) - Zigで書かれたネイティブドロッパーが正規の拡張機能を装い、人気コードエディタ全体にマルウェアを拡散
+2. [Aikido AttackがHoppscotchで複数の0-dayを発見](https://www.aikido.dev/blog/ai-pentest-hoppscotch-vulnerabilities) (2026-04-08) - AI駆動ペンテストがアカウント乗っ取りなど3件の高深刻度脆弱性を発見
+
+### Wiz
+
+1. [クラウド脅威回顧2026: AIが変えたもの、変えなかったもの](https://www.wiz.io/blog/cloud-threat-retrospective-2026) (2026-04-09) - AIがクラウドセキュリティ脅威にどう影響したかの分析
+2. [VercelとWizの連携でセキュリティ可視性を実現](https://www.wiz.io/blog/introducing-wiz-vercel-integration) (2026-04-09) - Vercel環境のアプリケーションリスク可視化
+
+## Claude Code / Kiro 最新情報
+
+### Claude Code チェンジログ
+
+**v2.1.97 (2026-04-08)**
+
+- Focus viewトグル（`Ctrl+O`）追加 ── NO_FLICKERモードでプロンプト・ツール概要・最終レスポンスを表示
+- ステータスラインのリフレッシュ間隔設定
+- Git worktree検出対応
+- エージェント可視化 ── `● N running`インジケーター追加
+- MCP HTTP/SSE接続のメモリリーク修正（~50 MB/hr）
+- 429レート制限リトライの指数バックオフ修正
+
+**v2.1.94 (2026-04-07)**
+
+- Amazon Bedrock Mantleサポート追加
+- デフォルトeffortレベルをmediumからhighに変更
+- Slack連携改善
+- CJKテキスト文字化け修正（UTF-8シーケンスのチャンク境界問題）
+
+### Kiro
+
+- [Kiroスタートアップクレジットプログラム再開](https://kiro.dev/blog/bringing-back-startup-credits/) (2026-04-07)
+- [MiniMax M2.5とGLM-5がKiroに対応](https://kiro.dev/blog/minimax-m25-and-glm-5/) (2026-04-02)
+
+## 用語集
+
+| 用語                         | 説明                                                                                         |
+| ---------------------------- | -------------------------------------------------------------------------------------------- |
+| MCP (Model Context Protocol) | AIモデルが外部ツールやデータソースに接続するためのプロトコル                                 |
+| DESIGN.md                    | Google Labs提唱のAI向けデザインシステム定義ファイル。Markdown形式でUI規約を記述              |
+| Claude Managed Agents        | AnthropicのAPIベースのエージェント管理サービス。マルチエージェント連携やセッション管理を提供 |
+| Vibe Coding                  | AIに大まかな意図を伝えて実装を任せる開発スタイル                                             |
+| GGUF                         | llama.cppで使われるLLMモデルの量子化フォーマット                                             |
+| Kepler-452b                  | 新たに注目されているオープンソースLLMモデル                                                  |
+| EXAONE 4.5                   | LG AI Researchが開発した33Bパラメータの大規模言語モデル                                      |
+| VeraCrypt                    | ディスク暗号化のオープンソースソフトウェア。TrueCryptの後継                                  |
+| Project Glasswing            | Anthropicが発表したAI時代の重要ソフトウェアを保護するセキュリティプロジェクト                |
+| Bedrock Mantle               | AWSのAIモデルホスティングサービスBedrock向けの新しい実行基盤                                 |
+| GlassWorm                    | Zig言語で書かれたIDEを標的とするマルウェアドロッパー                                         |
+| 認可制御不備                 | アクセス権限の確認が不十分なために、本来アクセスできないデータに触れてしまう脆弱性           |
+
+## 読書メモ
+
+（スキル実行時は空。ユーザーが記事を読んだ後に追記する）


### PR DESCRIPTION
## Summary
- 2026-04-09のトレンド情報収集記事（daily/20260409-trend.md）を追加
- はてブ、Hacker News、Reddit（14サブレッド）、セキュリティブログから収集
- 注目: MCPサーバー群公開、DESIGN.md、不動産100万件流出、テック業界8万人解雇

## Test plan
- [x] Markdown形式が正しいこと
- [x] localhost:3333で表示確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)