### PR TITLE
docs: 2026-04-17トレンド情報収集を追加

### DIFF
--- a/daily/20260417-trend.md
+++ b/daily/20260417-trend.md
@@ -124,7 +124,7 @@ WizがGitHub Actionsハードニングガイドを更新し、脅威モデルか
 21. [GitHub Stacked PRs](https://github.github.com/gh-stack/) (40 users) - GitHub製CLI
 22. [「ハンディカム」唯一の現行モデルが生産完了に](https://www.itmedia.co.jp/news/articles/2604/16/news111.html) (37 users) - 時代の終わり
 23. [macOS 版 Gemini ネイティブデスクトップアプリ](https://gemini.google/mac/) (35 users) - Google製Macアプリ
-24. [AIエージェント向けのパッケージマネージャー「ERNIE-Image」](https://gigazine.net/news/20260416-baidu-ernie-image/) (34 users) - Baidu画像生成
+24. [Baiduが画像生成AI「ERNIE-Image」を公開、ローカル実行＆プロンプト自動補完](https://gigazine.net/news/20260416-baidu-ernie-image/) (34 users) - Baidu画像生成モデル
 25. [WordPressのプラグイン31個にバックドアの存在が発覚](https://gigazine.net/news/20260414-wordpress-plugin-backdoor/) (32 users) - サプライチェーン攻撃
 26. [世界情勢が不安定な今こそ見直したい　オルカン＋個人向け国債](https://www.watch.impress.co.jp/docs/series/tsukamoto/2100041.html) (32 users) - 資産形成
 27. [世界がオープンソースAIを必要とする理由](https://shujisado.com/2026/04/15/why_world_needs_opensource_ai/) (30 users) - OSS AI論

--- a/daily/20260417-trend.md
+++ b/daily/20260417-trend.md
@@ -1,0 +1,335 @@
+---
+title: '2026-04-17 トレンド情報収集'
+date: '2026-04-17'
+---
+
+# 2026-04-17 トレンド情報収集
+
+## 今日のサマリー
+
+今日のトレンドは「**Claude Opus 4.7リリース**」と「**AIエージェント・ハーネス論**」が中心。ClaudeとQwenの新モデル競合、Kiro CLI 2.0の続報、GitHub Actionsセキュリティ、Cloudflareの新サービスラッシュなど、AI・開発・セキュリティが密に絡む1日となった。
+
+### Claude Opus 4.7公開とClaude Code大幅アップデート
+
+Anthropicが4月16日にClaude Opus 4.7を公開。指示追従性・画像認識・コード生成が強化され、解像度は従来の3倍（約375万画素）、価格はOpus 4.6と同額を維持した。同時にClaude Codeも2.1.108〜2.1.112までバージョンが進み、`xhigh`エフォート、`/effort`インタラクティブスライダー、`/ultrareview`による並列マルチエージェントPRレビュー、Windows PowerShellツール、1時間プロンプトキャッシュTTL、Recap機能など新機能が怒涛のように追加された。「Hacker News」では1日で1300pt超の注目を集めている。（[参考](https://www.anthropic.com/news/claude-opus-4-7)）
+
+### AIエージェント「ハーネス」論が日本でも加熱
+
+zennのAIエージェント″ハーネス″の混乱記事が231usersと急上昇。「Agent = Model + Harness」というAnthropic流の内部ハーネスと、Mitchell Hashimoto・OpenAIが指す「運用側の外部ハーネス」が混在している現状が指摘された。さらにQiitaの「Claude Codeをレベル5まで育てる」（CLAUDE.md→Skills→Hooks→Agents）が673usersを獲得し、「Claude Code流出から学ぶハーネスパターン10選」「takt入門」も続き、日本語圏でもハーネス設計が本格的な実践トピックに。（[参考](https://zenn.dev/watany/articles/d8b692bbca65a3)）
+
+### Qwen3.6-35B-A3Bリリース、ローカルLLMの勢力図が動く
+
+AlibabaのQwen3.6-35B-A3B（MoE、activated 3B）が公開され、HNで836pt、r/LocalLLaMAで1639upsを獲得。一部レビューではlaptop上でClaude Opus 4.7より優れたペリカンSVGを描画したとの報告もあり、「Agentic codingパワーが全員に開かれた」として、クローズドモデル一強時代の揺らぎを象徴している。Anthropicが身分証明書提示の検証を始めた動きとも相まって、「ローカル回帰」の機運が強まっている。（[参考](https://news.ycombinator.com/item?id=47792764)）
+
+### Kiro CLI：33秒で月4年分のビルド時間を救った事例
+
+Kiro公式ブログが「Root cause in 33 seconds」を投稿。設定パーサが関数呼び出しごとに再初期化されていたバグを、Kiroエージェントが自律的にコードベース概観→プロファイル読み込み→サブエージェント委任→修正実装を33秒で完遂した事例が紹介された。ビルド時間は30分超から1分未満に短縮、月間数十万ビルドで4年分の計算時間を節約。「汎用AIエージェントがオープンエンドな調査タスクに優れる」ことを示した象徴的ケース。（[参考](https://kiro.dev/blog/root-cause-in-33s/)）
+
+### セキュリティ：GitHub Actions・NIST NVD・AIアプリ保護の3本柱
+
+WizがGitHub Actionsハードニングガイドを更新し、脅威モデルから具体的防御策まで2部構成で公開。AikidoはNIST NVDがCVE情報付加を縮小する動きに対する代替CVEソースガイドを出した。さらに「Securing AI Applications From Inception to Deployment」でAIアプリのセキュリティを体系化。Claude Mythosのような自律攻撃エージェントが現実化しつつある中、防御側もエージェント時代に対応を迫られている。（[参考](https://www.wiz.io/blog/github-actions-security-guide)）
+
+---
+
+## 注目ピックアップ
+
+### [Claude Opus 4.7公開 — 指示追従性・画像認識・コード生成を強化](https://www.anthropic.com/news/claude-opus-4-7)
+
+> 4月16日リリース。コード生成と視覚処理が大幅強化され、画像入力は2,576ピクセル（約375万画素）まで対応（従来の3倍）。金融分析・ドキュメント推論・コーディング各ベンチでOpus 4.6を上回るが、Claude Mythos Previewには届かず。価格はOpus 4.6と同じ$5/$25per Mtokens。新`xhigh`エフォートレベルとtask budgets（ベータ）、`/ultrareview`スラッシュコマンドも同時投入。
+
+**ソース**: Hacker News 1325pt / r/ClaudeCode 2297 ups / はてブ 7 users
+**カテゴリ**: AI / Claude Code
+
+### [Claude Code を Level 5 まで育てたら、開発が「指示と確認だけ」になった](https://qiita.com/teppei19980914/items/8da88b33ffa8cf88dfa2)
+
+> Claude Codeを段階的にカスタマイズするアプローチを5レベルで整理。Level 1=素のプロンプト、Level 2=CLAUDE.md、Level 3=Skills、Level 4=Hooks、Level 5=Agents（複数レビュワー並列実行）と進化させる。「繰り返しの苦痛が次のレベルへの動機になる」という実践知が軸。ハーネス設計の入門として日本語圏で急速にシェアされている。
+
+**ソース**: はてブ 673 users
+**カテゴリ**: AI / Claude Code
+
+### [AIエージェントの"ハーネス"に関わる混乱と私見](https://zenn.dev/watany/articles/d8b692bbca65a3)
+
+> 「ハーネスエンジニアリング」という同じ言葉が立場により違う意味で使われている現状を整理。LangChain/Anthropicは「Agent=Model+Harness」として自社製品内の内部ハーネスを指す。一方Mitchell HashimotoやOpenAIユーザーガイドは、運用側が安全にエージェントを動かす外部ハーネスを指す。著者は用語の曖昧さを批判し、実務寄りの外部ハーネス重視の立場を取る。
+
+**ソース**: はてブ 231 users
+**カテゴリ**: AI / アーキテクチャ
+
+### [Root cause in 33 seconds: Kiro CLIが月4年分のビルド時間を救った](https://kiro.dev/blog/root-cause-in-33s/)
+
+> Kiro CLIが設定パーサの再初期化バグを33秒で突き止めた事例。コードベース概観→プロファイル読み込み→サブエージェント委任→実装を自律的に連鎖。ビルド時間は30分超→1分未満に短縮し、月間数十万ビルドで「4年分」の計算時間を節約。オープンエンドな調査タスクで汎用AIエージェントが威力を発揮することを示したケーススタディ。
+
+**ソース**: Kiro公式ブログ（Apr 16, 2026）
+**カテゴリ**: AI / Kiro
+
+### [Qwen3.6-35B-A3B released! — Agentic codingパワーが全員に公開](https://news.ycombinator.com/item?id=47792764)
+
+> AlibabaがQwen3.6-35B-A3B（MoE、activated 3B）をオープンリリース。Agentic codingタスクに最適化され、laptopローカルで動作。一部ユーザーはClaude Opus 4.7より優れたペリカンSVGを描画したとも報告。Claudeが身分証明書確認を始めた動きと相まって「ローカル回帰」のトリガーに。r/LocalLLaMAで1639ups、HN 836pt。
+
+**ソース**: Hacker News 836pt / r/LocalLLaMA 1639 ups
+**カテゴリ**: AI / OSS
+
+---
+
+## はてブIT（日本市場）
+
+### 注目トピック
+
+| タイトル                                                                                                                                                                                                        | ブクマ数       | 興味度 | カテゴリ       | メモ                           |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------ | -------------- | ------------------------------ |
+| [Claude Code を Level 5 まで育てたら、開発が「指示と確認だけ」になった](https://qiita.com/teppei19980914/items/8da88b33ffa8cf88dfa2)                                                                            | 673 users      | ★★★    | Claude Code    | ハーネス設計の5段階モデル      |
+| [Cloudflare、こんなに無料でいいんだろうか](https://note.com/o_ob/n/ndadf268735f4)                                                                                                                               | 523 users      | ★★     | Cloudflare     | 無料枠の充実ぶりを解説         |
+| [【有料級】Claude Codeで1人マーケ部門を作った全記録](https://note.com/kawaidesign/n/n229818b75aa1)                                                                                                              | 415 users      | ★★★    | AI活用         | マーケ業務を1人で回す実例      |
+| [転職してエクセル→HTML変換の仕事をしていたが、悪役令嬢は出てこず](https://zenn.dev/aldagram_tech/articles/c472e358412864)                                                                                       | 314 users      | ★★     | キャリア       | 渋めの業務体験記               |
+| [なぜ、日本のITは丸投げユーザー企業と御用聞きベンダーで成立したのか](https://zenn.dev/pdfractal/articles/3cba58622f7be6)                                                                                        | 259 users      | ★★     | 業界           | 構造分析                       |
+| [システムは「動く」だけでは足りない - 非機能要件・分散システム・トレードオフの基礎](https://speakerdeck.com/nwiizo/sisutemuha-dong-ku-dakedeha-zu-rinai-fei-ji-neng-yao-jian-fen-san-sisutemutoredoohunoji-chu) | 234 users      | ★★     | アーキテクチャ | スライド                       |
+| [AIエージェントの"ハーネス"に関わる混乱と私見](https://zenn.dev/watany/articles/d8b692bbca65a3)                                                                                                                 | 231 users      | ★★★    | AI             | 用語整理と批判的考察           |
+| [「Claude Code」デスクトップ版、めちゃ変わる "並列エージェント時代"に合わせて再設計](https://ascii.jp/elem/000/004/395/4395128/)                                                                                | 222 users      | ★★★    | Claude Code    | サイドバー・サイドチャット追加 |
+| [ClaudeがWindowsで壊れ続けている──Anthropicの死角](https://joho-todai.com/claude-windows-breaking-anthropic-blind-spot/)                                                                                        | 169 users      | ★★★    | Claude Code    | Windows対応の歪み              |
+| [セキュリティエンジニアはこう見る。認可制御不備を怪しむべき実装パターン10選](https://blog.flatt.tech/entry/authz_assessment_view)                                                                               | 162 users      | ★★★    | セキュリティ   | OWASP関連                      |
+| [今のPCでローカルLLMがどの程度動くのか、ブラウザで自動判定](https://pc.watch.impress.co.jp/docs/news/yajiuma/2102148.html)                                                                                      | 139 users      | ★★     | LLM            | 自前判定ツール                 |
+| [GitHub - microsoft/apm: Agent Package Manager](https://github.com/microsoft/apm)                                                                                                                               | 122 users      | ★★★    | AI             | Microsoft製APM                 |
+| [全社へのClaude Code大号令 — 1ヶ月で200個のアプリと300件のナレッジから見えたこと](https://note.com/naofumit/n/n2835cd8fbe87)                                                                                    | 96 users       | ★★★    | Claude Code    | 組織導入事例（前日比+）        |
+| [OllamaとOpenCodeでローカルAIコーディング環境を構築してみた](https://dev.classmethod.jp/articles/ollama-opencode-setup/)                                                                                        | 78 users       | ★★     | ローカルLLM    | 環境構築ガイド                 |
+| [「もう開発者はシークレットを使うな」GitHubが紹介する4つのセキュリティ対策](https://atmarkit.itmedia.co.jp/ait/articles/2604/13/news057.html)                                                                   | 75 users(継続) | ★★     | セキュリティ   | 前日から継続                   |
+| [光ファイバーを"マイク化"する盗聴攻撃](https://www.itmedia.co.jp/news/articles/2604/15/news029.html)                                                                                                            | 70 users       | ★★     | セキュリティ   | 新たな物理盗聴手法             |
+| [「Claude Mythos Preview」はネットワーク完全乗っ取り攻撃を自律的に実行できる](https://gigazine.net/news/20260414-claude-mythos-preview-aisi-evaluation/)                                                        | 57 users(継続) | ★★★    | AIセキュリティ | 継続注目                       |
+| [AI小説、星新一賞を席巻　人間と区別つかず](https://www.nikkei.com/article/DGXZQOUD0684S0W6A400C2000000/)                                                                                                        | 52 users       | ★★     | AI             | 社会影響                       |
+| [エンジニアに人気の「Claude Code」は何がすごい？](https://forest.watch.impress.co.jp/docs/serial/aidev/2097897.html)                                                                                            | 49 users(継続) | ★★★    | Claude Code    | 前日から継続                   |
+| [Cloudflare Email Service: now in public beta](https://blog.cloudflare.com/email-for-agents/)                                                                                                                   | 55 users       | ★★     | Cloudflare     | エージェント向けメール         |
+| [【LLM Wiki】Obsidian x Claude Codeで知識を構造化](https://zenn.dev/dely_jp/articles/8b55114cc0b958)                                                                                                            | 42 users       | ★★★    | Claude Code    | 知識管理                       |
+| [GitHub Stacked PRs](https://github.github.com/gh-stack/)                                                                                                                                                       | 40 users       | ★★     | 開発ツール     | Stacked PR CLI                 |
+
+### 全エントリー
+
+1. [Claude Code を Level 5 まで育てたら、開発が「指示と確認だけ」になった](https://qiita.com/teppei19980914/items/8da88b33ffa8cf88dfa2) (673 users) - Claude Code5段階カスタマイズのハーネス設計
+2. [Cloudflare、こんなに無料でいいんだろうか](https://note.com/o_ob/n/ndadf268735f4) (523 users) - Cloudflare無料枠の魅力
+3. [【有料級】Claude Codeで1人マーケ部門を作った全記録](https://note.com/kawaidesign/n/n229818b75aa1) (415 users) - 1人でマーケ業務を完遂
+4. [転職してエクセル読み解きHTML変換の仕事](https://zenn.dev/aldagram_tech/articles/c472e358412864) (314 users) - 地味な業務体験記
+5. [なぜ日本のITは丸投げと御用聞きで成立したのか](https://zenn.dev/pdfractal/articles/3cba58622f7be6) (259 users) - IT業界の構造問題
+6. [システムは「動く」だけでは足りない](https://speakerdeck.com/nwiizo/sisutemuha-dong-ku-dakedeha-zu-rinai-fei-ji-neng-yao-jian-fen-san-sisutemutoredoohunoji-chu) (234 users) - 非機能要件・分散システム解説
+7. [AIエージェントの"ハーネス"に関わる混乱と私見](https://zenn.dev/watany/articles/d8b692bbca65a3) (231 users) - ハーネス用語整理
+8. [「Claude Code」デスクトップ版、めちゃ変わる](https://ascii.jp/elem/000/004/395/4395128/) (222 users) - 並列エージェント対応UI刷新
+9. [ClaudeがWindowsで壊れ続けている──Anthropicの死角](https://joho-todai.com/claude-windows-breaking-anthropic-blind-spot/) (169 users) - Windows対応の課題
+10. [認可制御不備を怪しむべき実装パターン10選](https://blog.flatt.tech/entry/authz_assessment_view) (162 users) - セキュリティエンジニア視点
+11. [今のPCでローカルLLMがどの程度動くのか](https://pc.watch.impress.co.jp/docs/news/yajiuma/2102148.html) (139 users) - ブラウザ自動判定
+12. [GitHub - microsoft/apm: Agent Package Manager](https://github.com/microsoft/apm) (122 users) - AIエージェント向けパッケージ管理
+13. [全社へのClaude Code大号令 200個のアプリと300件のナレッジ](https://note.com/naofumit/n/n2835cd8fbe87) (96 users) - 組織導入1ヶ月の記録
+14. [OllamaとOpenCodeでローカルAIコーディング環境](https://dev.classmethod.jp/articles/ollama-opencode-setup/) (78 users) - ローカル環境構築
+15. [光ファイバーを"マイク化"する盗聴攻撃](https://www.itmedia.co.jp/news/articles/2604/15/news029.html) (70 users) - 物理レイヤ盗聴
+16. [「Claude Mythos Preview」はネットワーク乗っ取り攻撃を自律実行](https://gigazine.net/news/20260414-claude-mythos-preview-aisi-evaluation/) (57 users) - 攻撃エージェント検証
+17. [Cloudflare Email Service: now in public beta](https://blog.cloudflare.com/email-for-agents/) (55 users) - エージェント向けメール送受信
+18. [Claude Codeソースコード流出から学ぶハーネスパターン10選](https://qiita.com/nogataka/items/ebbbe74649eb441a34db) (26 users) - リーク解析ハーネス
+19. [エンジニアに人気の「Claude Code」は何がすごい？](https://forest.watch.impress.co.jp/docs/serial/aidev/2097897.html) (49 users) - 特徴解説
+20. [AI小説、星新一賞を席巻](https://www.nikkei.com/article/DGXZQOUD0684S0W6A400C2000000/) (52 users) - 賞の区分議論
+21. [GitHub Stacked PRs](https://github.github.com/gh-stack/) (40 users) - GitHub製CLI
+22. [「ハンディカム」唯一の現行モデルが生産完了に](https://www.itmedia.co.jp/news/articles/2604/16/news111.html) (37 users) - 時代の終わり
+23. [macOS 版 Gemini ネイティブデスクトップアプリ](https://gemini.google/mac/) (35 users) - Google製Macアプリ
+24. [AIエージェント向けのパッケージマネージャー「ERNIE-Image」](https://gigazine.net/news/20260416-baidu-ernie-image/) (34 users) - Baidu画像生成
+25. [WordPressのプラグイン31個にバックドアの存在が発覚](https://gigazine.net/news/20260414-wordpress-plugin-backdoor/) (32 users) - サプライチェーン攻撃
+26. [世界情勢が不安定な今こそ見直したい　オルカン＋個人向け国債](https://www.watch.impress.co.jp/docs/series/tsukamoto/2100041.html) (32 users) - 資産形成
+27. [世界がオープンソースAIを必要とする理由](https://shujisado.com/2026/04/15/why_world_needs_opensource_ai/) (30 users) - OSS AI論
+28. [TLSバージョンアップ前に知っておきたい、TLSv1.2と1.3の違い](https://zenn.dev/nttdata_tech/articles/9beb886173eaa2) (27 users) - プロトコル解説
+29. [Artifacts: Versioned storage that speaks Git (Cloudflare)](https://blog.cloudflare.com/artifacts-git-for-agents-beta/) (27 users) - エージェント向けGitストレージ
+30. [takt 入門 - AIマルチエージェントオーケストレーション](https://zenn.dev/rasshii/articles/dc19793edab99a) (28 users) - ワークフロー自動化
+31. [GitHub - vercel-labs/wterm: A terminal emulator for the web](https://github.com/vercel-labs/wterm) (25 users) - Vercel製Webターミナル
+32. [Windows 11のRecall機能からデータ抽出するTotalRecall Reloaded](https://gigazine.net/news/20260416-windows-recall-totalrecall-reloaded/) (18 users) - プライバシー懸念
+33. [PATも秘密鍵も管理せずGoogle CloudからGitHub APIにアクセス](https://product.10x.co.jp/entry/2026/04/15/163802) (20 users) - WIF活用
+34. [Hardening GitHub Actions: Lessons from Recent Attacks](https://www.wiz.io/blog/github-actions-security-guide) (16 users) - Wiz解説記事
+35. [【AI】Claude Codeが劣化すると開発者の言葉遣いが悪くなる](https://qiita.com/rana_kualu/items/1d019f33fd59fcbf1494) (15 users) - ミーム的観察
+36. [AIによるセキュリティリスクでOSSがクローズドへ移行](https://gigazine.net/news/20260416-cal-security-closed-source/) (13 users) - Cal.comのケース
+
+## Hacker News（グローバル）
+
+### 注目トピック
+
+| タイトル                                                                                                                 | ポイント | 興味度 | カテゴリ       | メモ                     |
+| ------------------------------------------------------------------------------------------------------------------------ | -------- | ------ | -------------- | ------------------------ |
+| [Claude Opus 4.7](https://news.ycombinator.com/item?id=47793411)                                                         | 1325pt   | ★★★    | Claude         | リリース当日のトップ記事 |
+| [Qwen3.6-35B-A3B: Agentic codingパワーが全員に開放](https://news.ycombinator.com/item?id=47792764)                       | 836pt    | ★★     | OSS LLM        | Alibaba新モデル          |
+| [Codex for almost everything](https://news.ycombinator.com/item?id=47796469)                                             | 599pt    | ★★     | OpenAI         | Codex活用記              |
+| [すべての未来は嘘だらけ：ここからどこへ行くのか](https://news.ycombinator.com/item?id=47792718)                          | 458pt    | ★      | 社会           | AI時代の情報論           |
+| [Qwen3.6-35B-A3BがlaptopでClaude Opus 4.7より良いペリカンを描いた](https://news.ycombinator.com/item?id=47796830)        | 237pt    | ★★     | OSS LLM        | ベンチ比較               |
+| [Cloudflare AI Platform: エージェント向け推論レイヤ](https://news.ycombinator.com/item?id=47792538)                      | 221pt    | ★★     | Cloudflare     | AI推論基盤               |
+| [Artifacts: Gitを話すバージョン管理ストレージ](https://news.ycombinator.com/item?id=47792374)                            | 136pt    | ★★     | Cloudflare     | AIエージェント向け       |
+| [Show HN: MacMind – 1989年Mac上のHyperCardで動くトランスフォーマー](https://news.ycombinator.com/item?id=47792525)       | 105pt    | ★      | 歴史           | 技術アート               |
+| [Android CLI: 任意のエージェントでAndroidアプリを3倍速で作る](https://news.ycombinator.com/item?id=47797665)             | 71pt     | ★★     | 開発ツール     | マルチエージェント対応   |
+| [Show HN: CodeBurn – Claude Codeのタスク別トークン利用量を解析](https://news.ycombinator.com/item?id=47759035)           | 66pt     | ★★★    | Claude Code    | コスト可視化ツール       |
+| [Launch HN: Kampala (YC W26) – アプリをAPIにリバースエンジニアリング](https://news.ycombinator.com/item?id=47794514)     | 62pt     | ★      | スタートアップ | YC新規                   |
+| [Official Clojure Documentary page](https://news.ycombinator.com/item?id=47798345)                                       | 56pt     | ★      | OSS            | ドキュメンタリー         |
+| [Tree-sitterによる優れたR言語プログラミング体験](https://news.ycombinator.com/item?id=47799573)                          | 43pt     | ★      | 言語           | R解析器                  |
+| [AI駆動のハードウェアハッカーアーム（ダクトテープ自作）](https://news.ycombinator.com/item?id=47800033)                  | 43pt     | ★      | ハードウェア   | DIY事例                  |
+| [GPT-Rosalind for life sciences research](https://news.ycombinator.com/item?id=47798244)                                 | 35pt     | ★      | AI研究         | ライフサイエンス特化     |
+| [Show HN: Marky – エージェンティックコーディング用の軽量Markdownビューア](https://news.ycombinator.com/item?id=47795468) | 21pt     | ★★     | ツール         | エージェント向け         |
+
+### 全エントリー
+
+1. [Claude Opus 4.7](https://news.ycombinator.com/item?id=47793411) (1325pt) - Anthropic新旗艦モデル公開
+2. [Qwen3.6-35B-A3B: Agentic codingパワーが全員に公開](https://news.ycombinator.com/item?id=47792764) (836pt) - Alibaba新MoE
+3. [Codex for almost everything](https://news.ycombinator.com/item?id=47796469) (599pt) - Codexでなんでもやる事例
+4. [すべての未来は嘘だらけ、ここからどこへ行くのか](https://news.ycombinator.com/item?id=47792718) (458pt) - AI時代の真実性
+5. [Qwen3.6-35B-A3BがClaude Opus 4.7より良いペリカンを描いた](https://news.ycombinator.com/item?id=47796830) (237pt) - ローカルモデル比較
+6. [Cloudflare AI Platform: エージェント向け推論レイヤ](https://news.ycombinator.com/item?id=47792538) (221pt) - Cloudflare新サービス
+7. [Artifacts: Gitを話すバージョン管理ストレージ](https://news.ycombinator.com/item?id=47792374) (136pt) - エージェント向けストレージ
+8. [Show HN: MacMind – 1989年Mac用HyperCard上のトランスフォーマー](https://news.ycombinator.com/item?id=47792525) (105pt) - 歴史技術
+9. [Android CLI: 任意のエージェントでAndroidを3倍速](https://news.ycombinator.com/item?id=47797665) (71pt) - エージェント開発
+10. [Show HN: CodeBurn – Claude Codeのタスク別トークン利用量解析](https://news.ycombinator.com/item?id=47759035) (66pt) - コスト分析
+11. [Launch HN: Kampala (YC W26)](https://news.ycombinator.com/item?id=47794514) (62pt) - スタートアップ
+12. [Official Clojure Documentary](https://news.ycombinator.com/item?id=47798345) (56pt) - Clojure映画
+13. [Tree-sitterによるR言語プログラミング体験](https://news.ycombinator.com/item?id=47799573) (43pt) - 言語ツール
+14. [AI駆動ハードウェアハッカーアーム](https://news.ycombinator.com/item?id=47800033) (43pt) - DIYハードウェア
+15. [GPT-Rosalind for life sciences](https://news.ycombinator.com/item?id=47798244) (35pt) - 研究AI
+16. [Show HN: Marky – 軽量Markdownビューア](https://news.ycombinator.com/item?id=47795468) (21pt) - エージェント向け
+
+## Claude Code Changelog（優先ソース）
+
+| バージョン | 日付       | 主な変更点                                                                                                                                          |
+| ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.1.112    | 2026-04-16 | Auto modeで「claude-opus-4-7 is temporarily unavailable」問題を修正                                                                                 |
+| 2.1.111    | 2026-04-16 | Opus 4.7 xhigh提供、Max購読者向けAuto mode、`/effort`スライダー、`/less-permission-prompts`スキル、`/ultrareview`コマンド、Windows PowerShellツール |
+| 2.1.110    | 2026-04-15 | `/tui`コマンド（フリッカーフリー描画）、プッシュ通知ツール、`Ctrl+O`で詳細切替、`/focus`コマンド、`autoScrollEnabled`設定                           |
+| 2.1.108    | 2026-04-14 | `ENABLE_PROMPT_CACHING_1H`環境変数、Recap機能、Skillツール経由のモデル探索、`/undo`エイリアス                                                       |
+| 2.1.105    | 2026-04-13 | `EnterWorktree`ツールの`path`パラメータ、PreCompactフック、バックグラウンドモニター、`/proactive`エイリアス                                         |
+
+## Kiro公式ブログ（優先ソース）
+
+| タイトル                                                                                                       | 日付       | メモ               |
+| -------------------------------------------------------------------------------------------------------------- | ---------- | ------------------ |
+| [Root cause in 33 seconds: How Kiro CLI saved 4 years of build time](https://kiro.dev/blog/root-cause-in-33s/) | 2026-04-16 | 自律バグ特定事例   |
+| [Run Kiro CLI programmatically: introducing headless mode](https://kiro.dev/blog/introducing-headless-mode/)   | 2026-04-13 | CI/CD自動化        |
+| [Planview saves 40+ hours per audit cycle with Kiro CLI](https://kiro.dev/blog/automating-soc-2-compliance/)   | 2026-04-10 | SOC 2自動化事例    |
+| [We're bringing back the Kiro startup credits program](https://kiro.dev/blog/bringing-back-startup-credits/)   | 2026-04-07 | スタートアップ支援 |
+
+## セキュリティブログ
+
+### Wiz Blog
+
+| タイトル                                                                                                                                                       | 日付       | 興味度 |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ |
+| [Securing AI Applications From Inception to Deployment](https://www.wiz.io/blog/securing-ai-application-from-inception-to-deployment)                          | 2026-04-16 | ★★★    |
+| [How to Harden GitHub Actions: An Updated Guide](https://www.wiz.io/blog/github-actions-security-guide)                                                        | 2026-04-15 | ★★★    |
+| [Securing the AI Edge: Wiz and Cloudflare Integrate](https://www.wiz.io/blog/wiz-cloudflare-ai-security-integration)                                           | 2026-04-14 | ★★     |
+| [Introducing Shadow Data Detection](https://www.wiz.io/blog/introducing-shadow-data-detection-in-wiz)                                                          | 2026-04-14 | ★★     |
+| [Primer on GitHub Actions Security - Threat Model, Attacks and Defenses (Part 1/2)](https://www.wiz.io/blog/github-actions-security-threat-model-and-defenses) | 2026-04-14 | ★★★    |
+
+### Aikido Blog
+
+| タイトル                                                                                                                                              | 日付       | 興味度 |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ |
+| [Reliable CVE sources in the age of NIST NVD cutbacks](https://www.aikido.dev/blog/nist-nvd-changes-2026)                                             | 2026-04-16 | ★★★    |
+| [Axios CVE-2026-40175: a critical bug that's… not exploitable](https://www.aikido.dev/blog/axios-cve-2026-40175-a-critical-bug-thats-not-exploitable) | 2026-04-14 | ★★     |
+| [Bug bounty isn't dead, but the old model is breaking](https://www.aikido.dev/blog/bug-bounty-isnt-dead)                                              | 2026-04-13 | ★★     |
+
+## Reddit（14サブレッド）
+
+### 注目トピック
+
+| タイトル                                                                                                                                                                    | 投票数   | コメント | 興味度 | サブレッド          | メモ             |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | ------ | ------------------- | ---------------- |
+| [Opus 4.7](https://www.reddit.com/r/ClaudeCode/comments/1sn5vdd/opus_47/)                                                                                                   | 2297 ups | 327      | ★★★    | r/ClaudeCode        | 最大反響         |
+| [Qwen3.6-35B-A3B released!](https://www.reddit.com/r/LocalLLaMA/comments/1sn3izh/qwen3635ba3b_released/)                                                                    | 1639 ups | 523      | ★★★    | r/LocalLLaMA        | 新OSSモデル      |
+| [Introducing Claude Opus 4.7 (公式)](https://www.reddit.com/r/ClaudeCode/comments/1sn57by/introducing_claude_opus_47_our_most_capable_opus/)                                | 1146 ups | 436      | ★★★    | r/ClaudeCode        | 公式告知         |
+| [So it begins (rate limit議論)](https://www.reddit.com/r/ClaudeCode/comments/1smxutl/so_it_begins/)                                                                         | 1113 ups | 139      | ★★★    | r/ClaudeCode        | レート制限       |
+| [Be Anthropic](https://www.reddit.com/r/ClaudeCode/comments/1sn730r/be_anthropic/)                                                                                          | 946 ups  | 34       | ★★     | r/ClaudeCode        | ミーム           |
+| [FCC exempts Netgear from ban on foreign routers](https://www.reddit.com/r/cybersecurity/comments/1smgf37/fcc_exempts_netgear_from_ban_on_foreign_routers/)                 | 855 ups  | 95       | ★★     | r/cybersecurity     | サプライチェーン |
+| [Should OpenAI release AI companion?](https://www.reddit.com/r/OpenAI/comments/1sn4n1g/should_openai_release_ai_companion/)                                                 | 678 ups  | 97       | ★      | r/OpenAI            | 議論喚起         |
+| [dude has a point (AI時代のweb)](https://www.reddit.com/r/webdev/comments/1sn6k8k/dude_has_a_point/)                                                                        | 655 ups  | 152      | ★★     | r/webdev            | 論点提起         |
+| [Claude had enough of this user](https://www.reddit.com/r/OpenAI/comments/1smu2rk/claude_had_enough_of_this_user/)                                                          | 569 ups  | 320      | ★★     | r/OpenAI            | AI拒絶事例       |
+| ["increased rate limits"](https://www.reddit.com/r/ClaudeCode/comments/1snbk2p/increased_rate_limits/)                                                                      | 425 ups  | 101      | ★★★    | r/ClaudeCode        | プラン改定       |
+| [Released Qwen3.6-35B-A3B](https://www.reddit.com/r/LocalLLaMA/comments/1sn3ikv/released_qwen3635ba3b/)                                                                     | 417 ups  | 88       | ★★     | r/LocalLLaMA        | 公式発表         |
+| [EU age verification app already hacked](https://www.reddit.com/r/cybersecurity/comments/1sn49qp/eu_age_verification_app_already_hacked/)                                   | 339 ups  | 50       | ★★★    | r/cybersecurity     | 早期破綻         |
+| [More reasons to go local: Claude requires ID verification](https://www.reddit.com/r/LocalLLaMA/comments/1sn7026/more_reasons_to_go_local_claude_is_beginning_to/)          | 304 ups  | 51       | ★★★    | r/LocalLLaMA        | プライバシー懸念 |
+| [I literally cannot understand my coworkers](https://www.reddit.com/r/cscareerquestions/comments/1sn2yl5/i_literally_cannot_understand_my_coworkers_what/)                  | 241 ups  | 112      | ★★     | r/cscareerquestions | キャリア議論     |
+| [I'm still new, Obsidian got 8 employees while other note apps got 100+](https://www.reddit.com/r/webdev/comments/1sm0004/im_still_new_why_obsidian_got_8_employees_and_1/) | 2195 ups | 244      | ★★     | r/webdev            | 個人開発         |
+| [Opus 4.7 Released!](https://www.reddit.com/r/ClaudeCode/comments/1sn5943/opus_47_released/)                                                                                | 206 ups  | 140      | ★★★    | r/ClaudeCode        | リリース反応     |
+| [Opus 4.7 nerfed?](https://www.reddit.com/r/ClaudeCode/comments/1sn9dw7/opus_47_nerfed/)                                                                                    | 176 ups  | 46       | ★★     | r/ClaudeCode        | 性能懸念         |
+
+### セキュリティ系
+
+1. [EU age verification app already hacked](https://www.reddit.com/r/cybersecurity/comments/1sn49qp/eu_age_verification_app_already_hacked/) (339 ups, 50 comments) - r/cybersecurity - EUの年齢認証アプリが早速ハックされた
+2. [FCC exempts Netgear from ban on foreign routers, doesn't explain why](https://www.reddit.com/r/cybersecurity/comments/1smgf37/fcc_exempts_netgear_from_ban_on_foreign_routers/) (855 ups, 95 comments) - r/cybersecurity - FCC免除が波紋
+3. [Two Americans sentenced for helping North Korea steal 5 million in fake IT worker scheme](https://www.reddit.com/r/cybersecurity/comments/1sn9987/two_americans_sentenced_for_helping_north_korea/) (61 ups, 1 comment) - r/cybersecurity - 偽IT労働者事件
+4. [QEMU abused to evade detection and enable ransomware delivery](https://www.reddit.com/r/cybersecurity/comments/1sn27ic/qemu_abused_to_evade_detection_and_enable/) (33 ups, 5 comments) - r/cybersecurity - QEMU悪用事例
+5. [RedSun: How Windows Defender's Remediation Became a SYSTEM File Write](https://www.reddit.com/r/netsec/comments/1snglu3/redsun_how_windows_defenders_remediation_became_a/) (9 ups, 1 comment) - r/netsec - Defender悪用
+6. [HAProxy HTTP/3 → HTTP/1 Desync: Cross-Protocol Smuggling via Standalone QUIC FIN (CVE-2026-33555)](https://www.reddit.com/r/netsec/comments/1snem8w/haproxy_http3_http1_desync_crossprotocol/) (8 ups, 2 comments) - r/netsec - 新CVE
+7. [Open dataset: 100k+ multimodal prompt injection samples](https://www.reddit.com/r/netsec/comments/1sn2o3v/open_dataset_100k_multimodal_prompt_injection/) (3 ups, 3 comments) - r/netsec - プロンプトインジェクションOSSデータセット
+8. [Common Entra ID Security Assessment Findings – Part 4: Weak Conditional Access Policies](https://www.reddit.com/r/netsec/comments/1sla6ju/common_entra_id_security_assessment_findings_part/) (12 ups, 2 comments) - r/netsec - Azure AD診断
+9. [Vishing attacks on Okta identity systems on the rise](https://www.reddit.com/r/cybersecurity/comments/1smw07e/vishing_attacks_on_okta_identity_systems_on_the/) (45 ups, 1 comment) - r/cybersecurity - Okta狙いの音声詐欺
+
+### AI系
+
+1. [Opus 4.7](https://www.reddit.com/r/ClaudeCode/comments/1sn5vdd/opus_47/) (2297 ups, 327 comments) - r/ClaudeCode - リリース反響最大
+2. [Qwen3.6-35B-A3B released!](https://www.reddit.com/r/LocalLLaMA/comments/1sn3izh/qwen3635ba3b_released/) (1639 ups, 523 comments) - r/LocalLLaMA - Alibaba新MoE
+3. [Introducing Claude Opus 4.7 (公式)](https://www.reddit.com/r/ClaudeCode/comments/1sn57by/introducing_claude_opus_47_our_most_capable_opus/) (1146 ups, 436 comments) - r/ClaudeCode - Anthropic公式
+4. [So it begins](https://www.reddit.com/r/ClaudeCode/comments/1smxutl/so_it_begins/) (1113 ups, 139 comments) - r/ClaudeCode - レート制限議論
+5. [Be Anthropic](https://www.reddit.com/r/ClaudeCode/comments/1sn730r/be_anthropic/) (946 ups, 34 comments) - r/ClaudeCode - ミーム
+6. [Should OpenAI release AI companion?](https://www.reddit.com/r/OpenAI/comments/1sn4n1g/should_openai_release_ai_companion/) (678 ups, 97 comments) - r/OpenAI - コンパニオンAI議論
+7. [Claude had enough of this user](https://www.reddit.com/r/OpenAI/comments/1smu2rk/claude_had_enough_of_this_user/) (569 ups, 320 comments) - r/OpenAI - AIが対話拒否した事例
+8. [increased rate limits](https://www.reddit.com/r/ClaudeCode/comments/1snbk2p/increased_rate_limits/) (425 ups, 101 comments) - r/ClaudeCode - プラン改定
+9. [Released Qwen3.6-35B-A3B](https://www.reddit.com/r/LocalLLaMA/comments/1sn3ikv/released_qwen3635ba3b/) (417 ups, 88 comments) - r/LocalLLaMA - 公式発表
+10. [More reasons to go local: Claude requires ID verification](https://www.reddit.com/r/LocalLLaMA/comments/1sn7026/more_reasons_to_go_local_claude_is_beginning_to/) (304 ups, 51 comments) - r/LocalLLaMA - 身分証明ID要求でローカル回帰
+11. [Is this from OpenAI or Grok?](https://www.reddit.com/r/OpenAI/comments/1smy4ne/is_this_from_openai_or_grok_the_rankings_climbing/) (260 ups, 38 comments) - r/OpenAI - ランキング急上昇分析
+12. [Opus 4.7 Released!](https://www.reddit.com/r/ClaudeCode/comments/1sn5943/opus_47_released/) (206 ups, 140 comments) - r/ClaudeCode - リリース感想
+13. [Opus 4.7 nerfed?](https://www.reddit.com/r/ClaudeCode/comments/1sn9dw7/opus_47_nerfed/) (176 ups, 46 comments) - r/ClaudeCode - 性能懸念
+14. [Only LocalLLaMA can save us now](https://www.reddit.com/r/LocalLLaMA/comments/1snbl1d/only_localllama_can_save_us_now/) (132 ups, 81 comments) - r/LocalLLaMA - ローカル論
+15. [Opus 4.7 = Un-nerfed Opus 4.6](https://www.reddit.com/r/ClaudeCode/comments/1sn7mlb/opus_47_unnerfed_opus_46/) (126 ups, 6 comments) - r/ClaudeCode - 性能比較
+16. [PSA: Qwen3.6 ships with preserve_thinking](https://www.reddit.com/r/LocalLLaMA/comments/1sne4gh/psa_qwen36_ships_with_preserve_thinking_make_sure/) (106 ups, 19 comments) - r/LocalLLaMA - 設定推奨
+17. [4.7 issues happening already](https://www.reddit.com/r/ClaudeCode/comments/1snfwxb/47_issues_happening_already/) (97 ups, 151 comments) - r/ClaudeCode - 不具合報告
+18. [Mozilla Announces "Thunderbolt" Open-Source Enterprise AI Client](https://www.reddit.com/r/LocalLLaMA/comments/1sn4ibj/mozilla_announces_thunderbolt_as_an_opensource/) (93 ups, 37 comments) - r/LocalLLaMA - OSSクライアント
+19. [Google, please open source Imagen, Gemini 1.0 Nano/Pro](https://www.reddit.com/r/LocalLLaMA/comments/1sncslc/google_please_just_open_source_imagen_2022_gemini/) (57 ups, 15 comments) - r/LocalLLaMA - OSS要望
+20. [Codex for (almost) everything](https://www.reddit.com/r/OpenAI/comments/1snakqv/codex_for_almost_everything/) (60 ups, 16 comments) - r/OpenAI - Codex活用
+21. [Comparison Qwen 3.6 35B MoE vs Qwen 3.5](https://www.reddit.com/r/LocalLLaMA/comments/1sn9iff/comparison_qwen_36_35b_moe_vs_qwen_35_35b_moe_on/) (51 ups, 25 comments) - r/LocalLLaMA - 世代比較
+22. [OpenAI sherlocked a bunch of YC startups today](https://www.reddit.com/r/OpenAI/comments/1snbrbf/openai_sherlocked_a_bunch_of_yc_startups_today/) (32 ups, 6 comments) - r/OpenAI - YC企業代替
+
+### コア技術系 / プログラミング
+
+1. [The API Tooling Crisis: Why developers are abandoning Postman and its clones?](https://www.reddit.com/r/programming/comments/1smyun6/the_api_tooling_crisis_why_developers_are/) (444 ups, 270 comments) - r/programming - API開発ツール議論
+2. [Dennis Ritchie on the double roles of & and | in Early C](https://www.reddit.com/r/programming/comments/1sn4yi9/dennis_ritchie_on_the_double_roles_of_and_in/) (106 ups, 24 comments) - r/programming - C言語史
+3. [Atomic Operations in Go](https://www.reddit.com/r/programming/comments/1smpas2/atomic_operations_in_go/) (56 ups, 12 comments) - r/programming - Go原子操作
+4. [Introduction to Spherical Harmonics for Graphics Programmers](https://www.reddit.com/r/programming/comments/1smz4im/introduction_to_spherical_harmonics_for_graphics/) (27 ups, 1 comment) - r/programming - グラフィックス数学
+5. [tiks – Procedural UI sounds in 2KB, zero audio files](https://www.reddit.com/r/javascript/comments/1smvqvy/tiks_procedural_ui_sounds_in_2kb_zero_audio_files/) (106 ups, 37 comments) - r/javascript - Web Audio合成
+6. [I built LiquidGlass, a JS lib to render pixel perfect iOS Liquid Glass effect](https://www.reddit.com/r/javascript/comments/1slupjv/i_built_liquidglass_a_js_lib_to_render_pixel/) (102 ups, 25 comments) - r/javascript - WebGL視覚効果
+7. [BrowserPod 2.0: in-browser WebAssembly sandboxes](https://www.reddit.com/r/javascript/comments/1smyuaz/browserpod_20_inbrowser_webassembly_sandboxes_run/) (15 ups, 2 comments) - r/javascript - ブラウザ内サンドボックス
+
+### OSS/個人開発系
+
+1. [The FSF respond to the Euro-Office/OnlyOffice scenario](https://www.reddit.com/r/opensource/comments/1smie7g/the_free_software_foundation_respond_to_the/) (237 ups, 9 comments) - r/opensource - FSF声明
+2. [Cal.com Goes Closed Source: Why AI Security Is Forcing Our Decision](https://www.reddit.com/r/opensource/comments/1sm9s80/calcom_goes_closed_source_why_ai_security_is/) (78 ups, 23 comments) - r/opensource - クローズド化事情
+3. [Cutting ties with Adobe CC... what's-what for PS, AI, and Acrobat?](https://www.reddit.com/r/opensource/comments/1snbrbs/cutting_ties_with_adobe_cc_whatswhat_for_ps_ai/) (10 ups, 7 comments) - r/opensource - Adobe代替
+4. [First month build saas, need advices to get revenue](https://www.reddit.com/r/indiehackers/comments/1skxvhn/first_month_build_saas_need_your_advices_to_get/) (29 ups, 76 comments) - r/indiehackers - 収益化相談
+5. ["I have not written a single line of code since November" - Boris Cherny](https://www.reddit.com/r/webdev/comments/1snh0it/i_have_not_written_a_single_line_of_code_since/) (8 ups, 16 comments) - r/webdev - Claude Code開発者の振り返り
+
+### キャリア/実践系
+
+1. [Allbirds stock tumbles after 600% rally as shoemaker rebrands as AI company](https://www.reddit.com/r/technology/comments/1snfim9/allbirds_stock_tumbles_after_nearly_600_rally_as/) (5066 ups, 368 comments) - r/technology - AIピボット失敗
+2. [Virginia voter support for new data centers collapses from 69% to 35%](https://www.reddit.com/r/technology/comments/1sn1i2o/virginia_voter_support_for_new_data_centers/) (10370 ups, 364 comments) - r/technology - データセンター反対論
+3. [Google Just Patented The End Of Your Website](https://www.reddit.com/r/technology/comments/1sn4lq5/google_just_patented_the_end_of_your_website/) (817 ups, 145 comments) - r/technology - AI Search特許
+4. [Snap laying off 16% of full-time staff](https://www.reddit.com/r/cscareerquestions/comments/1smlrag/snap_laying_off_16_of_fulltime_staff/) (1029 ups, 98 comments) - r/cscareerquestions - 大量リストラ
+5. [I literally cannot understand my coworkers, what do I do in meetings?](https://www.reddit.com/r/cscareerquestions/comments/1sn2yl5/i_literally_cannot_understand_my_coworkers_what/) (241 ups, 112 comments) - r/cscareerquestions - コミュニケーション悩み
+6. [New grad, recently joined a company and made a mistake](https://www.reddit.com/r/cscareerquestions/comments/1smu13b/new_grad_recently_joined_a_company_and_made_a/) (237 ups, 58 comments) - r/cscareerquestions - 新卒失敗
+7. [You are a senior/tech lead. 4-5 devs quit for 20% salary increase. What's next?](https://www.reddit.com/r/cscareerquestions/comments/1sn0jc5/you_are_a_seniortech_lead_you_overheard_45_devs/) (139 ups, 64 comments) - r/cscareerquestions - マネジメント課題
+8. [Laid off today and wife is expecting in August](https://www.reddit.com/r/cscareerquestions/comments/1sng5cz/laid_off_today_and_wife_is_expecting_in_august/) (112 ups, 36 comments) - r/cscareerquestions - 解雇体験
+9. [Junior tech postings down 67% and 43% of Class of 2026 underemployed](https://www.reddit.com/r/cscareerquestions/comments/1snhmje/junior_tech_postings_down_67_and_43_of_class_of/) (11 ups, 22 comments) - r/cscareerquestions - 新卒市場分析
+10. [How do you push back when management assumes AI generated code is production ready?](https://www.reddit.com/r/cscareerquestions/comments/1sng5bn/how_do_you_push_back_when_management_assumes_ai/) (14 ups, 33 comments) - r/cscareerquestions - AI過信問題
+11. [We need to stop acting like "hustle culture" is a good trait](https://www.reddit.com/r/productivity/comments/1smz9zu/we_need_to_stop_acting_like_hustle_culture_is_a/) (78 ups, 27 comments) - r/productivity - ハッスル文化批判
+12. [Tips on phone addiction management as someone who does social media](https://www.reddit.com/r/productivity/comments/1sn6t87/tips_on_phone_addiction_management_as_someone_who/) (10 ups, 4 comments) - r/productivity - スマホ依存
+
+## 用語集
+
+| 用語                               | 説明                                                                                                       |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| ハーネス(Harness)                  | AIエージェントを安全・効率的に動かすための周辺コード（プロンプト、ツール、フック、サンドボックス等）の総称 |
+| xhigh                              | Claude Code 2.1.111で導入された新しいエフォートレベル。標準high以上に時間と思考量を増やす                  |
+| /ultrareview                       | Claude Codeのスラッシュコマンド。ブランチやPRを並列マルチエージェントで網羅的レビューする                  |
+| Recap                              | Claude Code 2.1.108の機能。セッションコンテキストを要約し再接続時に復元する                                |
+| MoE (Mixture of Experts)           | パラメータの一部だけを活性化して推論する構造。Qwen3.6-35B-A3Bは35B中3Bのみ活性化                           |
+| xhigh/effort                       | 「エフォート」は思考ステップの予算。xhighはその最上位で、精度優先時に使う                                  |
+| CLAUDE.md                          | Claude Codeがプロジェクト実行時に読み込む規約・コンテキストファイル。「プロジェクトの憲法」に例えられる    |
+| PreCompactフック                   | Claude Codeがコンテキスト圧縮する直前に呼ばれるフック。重要情報の保全に使う                                |
+| WIF (Workload Identity Federation) | 長期認証情報を使わず外部IDプロバイダ経由でGCPにアクセスする仕組み                                          |
+| Stacked PR                         | 依存関係のある複数のPRを積み重ねる開発手法。gh-stackなどが支援                                             |
+| NIST NVD                           | 米国のCVEデータベース。CVE情報への付加情報提供を2026年以降縮小する動きがある                               |
+| Sherlocked                         | 大手プラットフォームが類似機能を公式実装し、サードパーティ製品を無効化すること                             |
+
+## 読書メモ
+
+（スキル実行時は空。ユーザーが記事を読んだ後に追記する）


### PR DESCRIPTION
## 主な変更点

`daily/20260417-trend.md` を新規追加しました。

### 収集した主要トピック

- **Claude Opus 4.7公開**（HN 1325pt / r/ClaudeCode 2297ups）— 指示追従性・画像認識・コード生成を強化、価格据置
- **Claude Code v2.1.108〜112の大型アップデート** — \`xhigh\`エフォート、\`/effort\`スライダー、\`/ultrareview\`、Windows PowerShellツール、1hプロンプトキャッシュ、Recap機能
- **Qwen3.6-35B-A3B公開**（HN 836pt / r/LocalLLaMA 1639ups）— Agentic coding特化のOSS MoEモデル
- **Kiro「Root cause in 33 seconds」** — エージェント自律調査で月4年分のビルド時間を節約
- **AIエージェント「ハーネス」論の加熱** — Zenn 231users、Qiita Level 5記事 673users
- **セキュリティ** — Wiz GitHub Actionsハードニング、Aikido NIST NVD代替ソース、Cal.com OSS離脱

### レビュー対応

- ultrareviewでエントリ24のラベル誤り（ERNIE-ImageをAIエージェント向けパッケージマネージャーと誤記）を指摘 → 実際の記事タイトルに沿って修正（f0622b9）

## テスト

- [x] \`npm run dev\`（ポート3333で既存稼働）で \`http://localhost:3333/daily/20260417/\` が200で表示されることを確認
- [x] 前日ファイル（20260414-trend.md）とのURL重複排除を実施
- [x] prettier自動整形（lint-stagedフック）が適用済み

## 関連タスク

- \`/neta-trend-daily\` スキルの2026-04-17実行分

## その他

- 前セッションから残っている \`posts/0084_gaussian-splatting-babylonjs-guide.md\` は本PRには含めていません