### PR TITLE
fix: ロードマップページのMermaid図レンダリング修正

### DIFF
--- a/src/components/MermaidArticleContent.tsx
+++ b/src/components/MermaidArticleContent.tsx
@@ -1,11 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
-import dynamic from 'next/dynamic'
-
-const MermaidRenderer = dynamic(() => import('@/components/MermaidRenderer'), {
-  ssr: false,
-})
+import { useEffect, useRef } from 'react'
 
 interface MermaidArticleContentProps {
   contentHtml: string
@@ -16,32 +11,64 @@ interface MermaidArticleContentProps {
  * ロードマップ、技術選定など複数のセクションで共通利用する
  */
 export default function MermaidArticleContent({ contentHtml }: MermaidArticleContentProps) {
+  const articleRef = useRef<HTMLElement>(null)
+
   useEffect(() => {
-    import('mermaid').then((mermaid) => {
-      mermaid.default.initialize({
-        startOnLoad: true,
-        theme: 'default',
+    const initMermaid = async () => {
+      const mermaid = (await import('mermaid')).default
+
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'dark',
         securityLevel: 'loose',
         themeVariables: {
-          primaryColor: '#e1f5fe',
-          primaryTextColor: '#000',
-          primaryBorderColor: '#0066cc',
-          lineColor: '#5a5a5a',
-          secondaryColor: '#fff3e0',
-          tertiaryColor: '#f3e5f5',
+          primaryColor: '#1e293b',
+          primaryTextColor: '#f1f5f9',
+          primaryBorderColor: '#475569',
+          lineColor: '#64748b',
+          secondaryColor: '#334155',
+          tertiaryColor: '#475569',
+          background: '#0f172a',
+          mainBkg: '#1e293b',
+          secondBkg: '#334155',
+          tertiaryBkg: '#475569',
+          textColor: '#f1f5f9',
         },
       })
-      mermaid.default.contentLoaded()
-    })
-  }, [])
+
+      if (!articleRef.current) return
+      const elements = articleRef.current.querySelectorAll('.mermaid')
+      if (elements.length > 0) {
+        try {
+          await mermaid.run({
+            nodes: Array.from(elements) as HTMLElement[],
+          })
+        } catch (error) {
+          console.error('Mermaid rendering error:', error)
+          elements.forEach((el) => {
+            const htmlEl = el as HTMLElement
+            if (htmlEl.textContent && !htmlEl.querySelector('svg')) {
+              htmlEl.style.padding = '1rem'
+              htmlEl.style.backgroundColor = '#1e293b'
+              htmlEl.style.border = '1px solid #475569'
+              htmlEl.style.borderRadius = '0.375rem'
+              htmlEl.style.fontFamily = 'monospace'
+              htmlEl.style.whiteSpace = 'pre-wrap'
+              htmlEl.style.color = '#f1f5f9'
+            }
+          })
+        }
+      }
+    }
+
+    initMermaid().catch(console.error)
+  }, [contentHtml])
 
   return (
-    <>
-      <article
-        className="prose dark:prose-invert max-w-none"
-        dangerouslySetInnerHTML={{ __html: contentHtml }}
-      />
-      <MermaidRenderer />
-    </>
+    <article
+      ref={articleRef}
+      className="prose dark:prose-invert max-w-none"
+      dangerouslySetInnerHTML={{ __html: contentHtml }}
+    />
   )
 }

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -250,19 +250,43 @@ export async function getRoadmapPostData(slug: string): Promise<RoadmapPostDetai
   const fileContents = fs.readFileSync(fullPath, 'utf8')
   const matterResult = matter(fileContents)
 
+  let content = matterResult.content
+  const mermaidRegex = /```mermaid\r?\n([\s\S]*?)\r?\n```/g
+  const mermaidBlocks: string[] = []
+  let mermaidIndex = 0
+
+  content = content.replace(mermaidRegex, (_, code) => {
+    const escapedCode = code
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+    mermaidBlocks.push(escapedCode)
+    return `\n<!-- MERMAID_PLACEHOLDER_${mermaidIndex++} -->\n`
+  })
+
   const processedContent = await remark()
     .use(remarkGfm)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
     .use(rehypeSlug)
     .use(rehypeStringify)
-    .process(matterResult.content)
+    .process(content)
+
+  let contentHtml = processedContent.toString()
+
+  mermaidBlocks.forEach((code, index) => {
+    const placeholder = `<!-- MERMAID_PLACEHOLDER_${index} -->`
+    const mermaidDiv = `<div class="mermaid">${code}</div>`
+    contentHtml = contentHtml.replace(placeholder, mermaidDiv)
+  })
 
   return {
     slug,
     title: (matterResult.data.title as string) || slug,
     order: (matterResult.data.order as number) || 0,
     section: (matterResult.data.section as string) || '',
-    contentHtml: processedContent.toString(),
+    contentHtml,
   }
 }


### PR DESCRIPTION
## 主な変更点

`/note/roadmap/[slug]` のサブページでMermaid図が生テキストのまま表示される問題を修正。

### 原因
- `roadmap.ts`に` ```mermaid` → `<div class="mermaid">` への変換処理がなかった（`posts.ts`にはあった）
- `MermaidArticleContent`が`contentLoaded()`を使っていたが、`dangerouslySetInnerHTML`のレンダリングとの競合で不安定だった

### 修正内容
1. **`src/lib/roadmap.ts`**: Mermaidブロックのプレースホルダー処理を追加（posts.tsと同等のロジック）
2. **`src/components/MermaidArticleContent.tsx`**: `contentLoaded()` → `mermaid.run()`に変更。ref経由で明示的にノードを指定し安定化。ダークテーマも統一。

## テスト

- [x] localhost:3333でarchitecture-patternsページの4つのMermaid図がSVGレンダリングされることを確認
- [x] TypeScriptの型チェック通過