### PR TITLE
feat: AWS全資格取得ロードマップ2026ページを追加

### DIFF
--- a/src/app/note/aws-cert/[slug]/page.tsx
+++ b/src/app/note/aws-cert/[slug]/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getAllCertSlugs, getCertPostData, certSections } from '@/lib/aws-cert'
+import MermaidArticleContent from '@/components/MermaidArticleContent'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateStaticParams() {
+  const slugs = getAllCertSlugs()
+  return slugs.map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const post = await getCertPostData(slug)
+  return {
+    title: post ? `${post.title} - AWS資格学習ノート` : slug,
+  }
+}
+
+function findAdjacentSlugs(currentSlug: string) {
+  const allItems = certSections.flatMap((s) => s.items)
+  const currentIndex = allItems.findIndex((item) => item.slug === currentSlug)
+  const prev = currentIndex > 0 ? allItems[currentIndex - 1] : null
+  const next = currentIndex < allItems.length - 1 ? allItems[currentIndex + 1] : null
+  return { prev, next }
+}
+
+export default async function CertPostPage({ params }: PageProps) {
+  const { slug } = await params
+  const post = await getCertPostData(slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  const { prev, next } = findAdjacentSlugs(slug)
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 px-4">
+      <nav className="mb-6">
+        <Link
+          href="/note/aws-cert"
+          className="text-blue-400 hover:text-blue-300 hover:underline text-sm"
+        >
+          ← AWS資格ロードマップへ
+        </Link>
+      </nav>
+
+      <h1 className="text-3xl font-bold mb-1">{post.title}</h1>
+      <p className="text-gray-500 text-sm mb-8">{post.code}</p>
+
+      <MermaidArticleContent contentHtml={post.contentHtml} />
+
+      <nav className="mt-12 pt-6 border-t border-gray-700 flex justify-between">
+        {prev ? (
+          <Link
+            href={`/note/aws-cert/${prev.slug}/`}
+            className="text-blue-400 hover:text-blue-300 hover:underline text-sm"
+          >
+            ← {prev.title}
+          </Link>
+        ) : (
+          <span />
+        )}
+        {next ? (
+          <Link
+            href={`/note/aws-cert/${next.slug}/`}
+            className="text-blue-400 hover:text-blue-300 hover:underline text-sm"
+          >
+            {next.title} →
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </div>
+  )
+}

--- a/src/app/note/aws-cert/page.tsx
+++ b/src/app/note/aws-cert/page.tsx
@@ -1,0 +1,190 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import {
+  certSections,
+  getExistingCertSlugs,
+  getCertProgress,
+  type CertStatus,
+} from '@/lib/aws-cert'
+
+export const metadata: Metadata = {
+  title: 'AWS全資格取得ロードマップ 2026',
+  description: '2026年中にAWS認定資格を全12種取得するためのロードマップと進捗管理',
+}
+
+const statusConfig: Record<CertStatus, { label: string; bg: string; text: string }> = {
+  'not-started': { label: '未着手', bg: 'bg-gray-700', text: 'text-gray-400' },
+  studying: { label: '学習中', bg: 'bg-blue-900', text: 'text-blue-300' },
+  scheduled: { label: '受験予定', bg: 'bg-yellow-900', text: 'text-yellow-300' },
+  passed: { label: '合格', bg: 'bg-green-900', text: 'text-green-300' },
+}
+
+const levelColor: Record<string, string> = {
+  foundational: 'border-gray-500',
+  associate: 'border-blue-500',
+  professional: 'border-purple-500',
+  specialty: 'border-amber-500',
+}
+
+export default function AwsCertPage() {
+  const existingSlugs = getExistingCertSlugs()
+  const progress = getCertProgress()
+  const progressPercent = Math.round((progress.passed / progress.total) * 100)
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 px-4">
+      <nav className="mb-6">
+        <Link href="/note" className="text-blue-400 hover:text-blue-300 hover:underline text-sm">
+          ← Note一覧へ
+        </Link>
+      </nav>
+
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold mb-2">AWS全資格取得ロードマップ 2026</h1>
+        <p className="text-gray-400 text-sm mb-6">
+          2026年中にAWS認定資格を全12種取得することを目標に、学習の進捗を管理するページ。
+          各資格のリンクをクリックすると学習ノートを閲覧できる。
+        </p>
+
+        {/* 進捗バー */}
+        <div className="bg-gray-800 rounded-xl p-5 border border-gray-700">
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-sm font-bold text-gray-200">全体進捗</span>
+            <span className="text-sm text-gray-400">
+              {progress.passed} / {progress.total} 合格 ({progressPercent}%)
+            </span>
+          </div>
+          <div className="w-full bg-gray-700 rounded-full h-3 mb-4">
+            <div
+              className="bg-green-500 h-3 rounded-full transition-all"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+          <div className="flex gap-6 text-xs text-gray-400">
+            <span>
+              <span className="inline-block w-2 h-2 rounded-full bg-green-500 mr-1" />
+              合格: {progress.passed}
+            </span>
+            <span>
+              <span className="inline-block w-2 h-2 rounded-full bg-yellow-500 mr-1" />
+              受験予定: {progress.scheduled}
+            </span>
+            <span>
+              <span className="inline-block w-2 h-2 rounded-full bg-blue-500 mr-1" />
+              学習中: {progress.studying}
+            </span>
+            <span>
+              <span className="inline-block w-2 h-2 rounded-full bg-gray-500 mr-1" />
+              未着手: {progress.total - progress.passed - progress.studying - progress.scheduled}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* 資格一覧 */}
+      <div className="space-y-10">
+        {certSections.map((section) => (
+          <div key={section.id}>
+            <h2
+              className={`text-xl font-bold mb-4 text-gray-200 border-b pb-2 ${levelColor[section.id] || 'border-gray-700'}`}
+            >
+              {section.title}
+            </h2>
+            <div className="space-y-3">
+              {section.items.map((item) => {
+                const hasContent = existingSlugs.has(item.slug)
+                const sc = statusConfig[item.status]
+
+                return (
+                  <div
+                    key={item.slug}
+                    className="flex items-center gap-3 p-3 rounded-lg bg-gray-800/50 border border-gray-700/50"
+                  >
+                    {/* ステータスバッジ */}
+                    <span
+                      className={`px-2 py-0.5 text-xs font-bold rounded ${sc.bg} ${sc.text} min-w-[60px] text-center`}
+                    >
+                      {sc.label}
+                    </span>
+
+                    {/* 資格名 */}
+                    <div className="flex-1 min-w-0">
+                      {hasContent ? (
+                        <Link
+                          href={`/note/aws-cert/${item.slug}/`}
+                          className="text-blue-400 hover:text-blue-300 hover:underline"
+                        >
+                          {item.title}
+                        </Link>
+                      ) : (
+                        <span className="text-gray-300">{item.title}</span>
+                      )}
+                      <span className="ml-2 text-xs text-gray-500">{item.code}</span>
+                    </div>
+
+                    {/* 目標月 */}
+                    {item.targetMonth && (
+                      <span className="text-xs text-gray-500 whitespace-nowrap">
+                        目標: {item.targetMonth}
+                      </span>
+                    )}
+
+                    {/* 合格日 */}
+                    {item.passedDate && (
+                      <span className="text-xs text-green-400 whitespace-nowrap">
+                        合格: {item.passedDate}
+                      </span>
+                    )}
+
+                    {/* ノートリンク */}
+                    {hasContent && (
+                      <Link
+                        href={`/note/aws-cert/${item.slug}/`}
+                        className="text-xs text-gray-500 hover:text-blue-400"
+                      >
+                        ノート →
+                      </Link>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* タイムライン */}
+      <div className="mt-12 pt-8 border-t border-gray-700">
+        <h2 className="text-xl font-bold mb-6 text-gray-200">受験スケジュール</h2>
+        <div className="space-y-2">
+          {[
+            { month: '5月', certs: ['Cloud Practitioner'] },
+            { month: '6月', certs: ['Solutions Architect - Associate'] },
+            { month: '7月', certs: ['Developer - Associate'] },
+            { month: '8月', certs: ['SysOps Administrator - Associate'] },
+            { month: '9月', certs: ['Solutions Architect - Professional'] },
+            { month: '10月', certs: ['DevOps Engineer - Professional', 'Security - Specialty'] },
+            { month: '11月', certs: ['Database', 'Machine Learning', 'Data Analytics'] },
+            { month: '12月', certs: ['Advanced Networking', 'SAP on AWS'] },
+          ].map((item) => (
+            <div key={item.month} className="flex gap-4 items-start">
+              <span className="text-sm font-bold text-gray-300 w-12 shrink-0 pt-0.5">
+                {item.month}
+              </span>
+              <div className="flex-1 flex flex-wrap gap-2">
+                {item.certs.map((cert) => (
+                  <span
+                    key={cert}
+                    className="px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-400"
+                  >
+                    {cert}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/note/page.tsx
+++ b/src/app/note/page.tsx
@@ -52,6 +52,15 @@ const noteSections: NoteSection[] = [
     status: 'new',
   },
   {
+    title: 'AWS全資格取得ロードマップ 2026',
+    description:
+      '2026年中にAWS認定資格を全12種取得するためのロードマップ。学習ノートと進捗管理付き',
+    href: '/note/aws-cert',
+    color: 'orange',
+    tags: ['AWS', '資格', 'クラウド', 'ロードマップ'],
+    status: 'new',
+  },
+  {
     title: 'ブラウザゲームコレクション',
     description:
       'HTML5 Canvas APIで作成したミニゲーム集。テトリス、スネーク、2048などクラシックゲームをプレイ可能',

--- a/src/lib/aws-cert.ts
+++ b/src/lib/aws-cert.ts
@@ -1,0 +1,249 @@
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import { remark } from 'remark'
+import remarkGfm from 'remark-gfm'
+import remarkRehype from 'remark-rehype'
+import rehypeRaw from 'rehype-raw'
+import rehypeSlug from 'rehype-slug'
+import rehypeStringify from 'rehype-stringify'
+
+const awsCertDirectory = path.join(process.cwd(), 'aws-cert')
+
+export type CertStatus = 'not-started' | 'studying' | 'scheduled' | 'passed'
+
+export interface CertItem {
+  slug: string
+  title: string
+  code: string
+  level: 'foundational' | 'associate' | 'professional' | 'specialty'
+  status: CertStatus
+  targetMonth?: string
+  examDate?: string
+  passedDate?: string
+}
+
+export interface CertSection {
+  id: string
+  title: string
+  items: CertItem[]
+}
+
+export interface CertPostDetail {
+  slug: string
+  title: string
+  code: string
+  level: string
+  contentHtml: string
+}
+
+export const certSections: CertSection[] = [
+  {
+    id: 'foundational',
+    title: 'Foundational',
+    items: [
+      {
+        slug: 'cloud-practitioner',
+        title: 'Cloud Practitioner',
+        code: 'CLF-C02',
+        level: 'foundational',
+        status: 'not-started',
+        targetMonth: '2026-05',
+      },
+    ],
+  },
+  {
+    id: 'associate',
+    title: 'Associate',
+    items: [
+      {
+        slug: 'solutions-architect-associate',
+        title: 'Solutions Architect - Associate',
+        code: 'SAA-C03',
+        level: 'associate',
+        status: 'not-started',
+        targetMonth: '2026-06',
+      },
+      {
+        slug: 'developer-associate',
+        title: 'Developer - Associate',
+        code: 'DVA-C02',
+        level: 'associate',
+        status: 'not-started',
+        targetMonth: '2026-07',
+      },
+      {
+        slug: 'sysops-administrator',
+        title: 'SysOps Administrator - Associate',
+        code: 'SOA-C02',
+        level: 'associate',
+        status: 'not-started',
+        targetMonth: '2026-08',
+      },
+    ],
+  },
+  {
+    id: 'professional',
+    title: 'Professional',
+    items: [
+      {
+        slug: 'solutions-architect-professional',
+        title: 'Solutions Architect - Professional',
+        code: 'SAP-C02',
+        level: 'professional',
+        status: 'not-started',
+        targetMonth: '2026-09',
+      },
+      {
+        slug: 'devops-engineer-professional',
+        title: 'DevOps Engineer - Professional',
+        code: 'DOP-C02',
+        level: 'professional',
+        status: 'not-started',
+        targetMonth: '2026-10',
+      },
+    ],
+  },
+  {
+    id: 'specialty',
+    title: 'Specialty',
+    items: [
+      {
+        slug: 'security-specialty',
+        title: 'Security - Specialty',
+        code: 'SCS-C02',
+        level: 'specialty',
+        status: 'not-started',
+        targetMonth: '2026-10',
+      },
+      {
+        slug: 'database-specialty',
+        title: 'Database - Specialty',
+        code: 'DBS-C01',
+        level: 'specialty',
+        status: 'not-started',
+        targetMonth: '2026-11',
+      },
+      {
+        slug: 'machine-learning-specialty',
+        title: 'Machine Learning - Specialty',
+        code: 'MLS-C01',
+        level: 'specialty',
+        status: 'not-started',
+        targetMonth: '2026-11',
+      },
+      {
+        slug: 'data-analytics-specialty',
+        title: 'Data Analytics - Specialty',
+        code: 'DAS-C01',
+        level: 'specialty',
+        status: 'not-started',
+        targetMonth: '2026-11',
+      },
+      {
+        slug: 'advanced-networking-specialty',
+        title: 'Advanced Networking - Specialty',
+        code: 'ANS-C01',
+        level: 'specialty',
+        status: 'not-started',
+        targetMonth: '2026-12',
+      },
+      {
+        slug: 'sap-on-aws-specialty',
+        title: 'SAP on AWS - Specialty',
+        code: 'PAS-C01',
+        level: 'specialty',
+        status: 'not-started',
+        targetMonth: '2026-12',
+      },
+    ],
+  },
+]
+
+export function getExistingCertSlugs(): Set<string> {
+  if (!fs.existsSync(awsCertDirectory)) {
+    return new Set()
+  }
+  return new Set(
+    fs
+      .readdirSync(awsCertDirectory)
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => f.replace(/\.md$/, ''))
+  )
+}
+
+export function getAllCertSlugs(): string[] {
+  if (!fs.existsSync(awsCertDirectory)) {
+    return []
+  }
+  return fs
+    .readdirSync(awsCertDirectory)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.replace(/\.md$/, ''))
+}
+
+export async function getCertPostData(slug: string): Promise<CertPostDetail | null> {
+  const fullPath = path.join(awsCertDirectory, `${slug}.md`)
+
+  if (!fs.existsSync(fullPath)) {
+    return null
+  }
+
+  const fileContents = fs.readFileSync(fullPath, 'utf8')
+  const matterResult = matter(fileContents)
+
+  let content = matterResult.content
+  const mermaidRegex = /```mermaid\r?\n([\s\S]*?)\r?\n```/g
+  const mermaidBlocks: string[] = []
+  let mermaidIndex = 0
+
+  content = content.replace(mermaidRegex, (_, code) => {
+    const escapedCode = code
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+    mermaidBlocks.push(escapedCode)
+    return `\n<!-- MERMAID_PLACEHOLDER_${mermaidIndex++} -->\n`
+  })
+
+  const processedContent = await remark()
+    .use(remarkGfm)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeSlug)
+    .use(rehypeStringify)
+    .process(content)
+
+  let contentHtml = processedContent.toString()
+
+  mermaidBlocks.forEach((code, index) => {
+    const placeholder = `<!-- MERMAID_PLACEHOLDER_${index} -->`
+    const mermaidDiv = `<div class="mermaid">${code}</div>`
+    contentHtml = contentHtml.replace(placeholder, mermaidDiv)
+  })
+
+  return {
+    slug,
+    title: (matterResult.data.title as string) || slug,
+    code: (matterResult.data.code as string) || '',
+    level: (matterResult.data.level as string) || '',
+    contentHtml,
+  }
+}
+
+export function getCertProgress(): {
+  total: number
+  passed: number
+  studying: number
+  scheduled: number
+} {
+  const allItems = certSections.flatMap((s) => s.items)
+  return {
+    total: allItems.length,
+    passed: allItems.filter((i) => i.status === 'passed').length,
+    studying: allItems.filter((i) => i.status === 'studying').length,
+    scheduled: allItems.filter((i) => i.status === 'scheduled').length,
+  }
+}


### PR DESCRIPTION
## 主な変更点

`/note/aws-cert/` にAWS認定全12資格の取得ロードマップページを新設。

### 機能
- **進捗管理**: 合格/受験予定/学習中/未着手の4ステータスとプログレスバー
- **レベル別表示**: Foundational → Associate → Professional → Specialty
- **月別スケジュール**: 5月〜12月の受験計画タイムライン
- **学習ノート**: `aws-cert/` ディレクトリにmdファイルを追加すると個別ページとして表示
- **Mermaid対応**: 学習ノート内でMermaid図を使用可能

### ファイル構成
- `src/lib/aws-cert.ts` — データ定義・進捗計算・md読み込み
- `src/app/note/aws-cert/page.tsx` — 資格一覧ページ
- `src/app/note/aws-cert/[slug]/page.tsx` — 個別学習ノートページ
- `src/app/note/page.tsx` — noteインデックスにリンク追加

### 使い方
ステータスや目標月を変更するには `src/lib/aws-cert.ts` の `certSections` を編集する。
学習ノートは `aws-cert/{slug}.md` にmdファイルを置くだけで反映される。

## テスト

- [x] localhost:3333で一覧ページの表示確認
- [x] TypeScriptの型チェック通過